### PR TITLE
fix model.decision_function error

### DIFF
--- a/examples/sklearn_to_hls.py
+++ b/examples/sklearn_to_hls.py
@@ -24,7 +24,7 @@ model = conifer.model(clf, conifer.converters.sklearn, conifer.backends.vivadohl
 model.compile()
 
 # Run HLS C Simulation and get the output
-y_hls = model.decision_function(X)[:,0]
+y_hls = model.decision_function(X)
 y_skl = clf.decision_function(X)
 
 # Synthesize the model


### PR DESCRIPTION
This is in reference to issue https://github.com/thesps/conifer/issues/2. 

The "y_hls = model.decision_function(X)[:,0]" line throws an error since the output of model.decision_function(X) is a 1D array. To fix this, I just took out [:.,0].