### PR TITLE
Allow user to run cosim and export from calling build function

### DIFF
--- a/conifer/backends/vivadohls/hls-template/build_prj.tcl
+++ b/conifer/backends/vivadohls/hls-template/build_prj.tcl
@@ -50,7 +50,7 @@ if {$opt(synth)} {
 }
 
 if {$opt(cosim)} {
-    cosim_design -trace_level al
+    cosim_design -trace_level all
 }
 
 if {$opt(export)} {

--- a/conifer/backends/vivadohls/hls-template/build_prj.tcl
+++ b/conifer/backends/vivadohls/hls-template/build_prj.tcl
@@ -50,10 +50,10 @@ if {$opt(synth)} {
 }
 
 if {$opt(cosim)} {
-    cosim_design -trace_level all
+    cosim_design -trace_level al
 }
 
-if {$opt(vsynth)} {
+if {$opt(export)} {
     export_design -format ip_catalog
 }
 

--- a/conifer/backends/vivadohls/writer.py
+++ b/conifer/backends/vivadohls/writer.py
@@ -233,9 +233,11 @@ def decision_function(X, config, trees=False):
                X, delimiter=",", fmt='%10f')
     cwd = os.getcwd()
     os.chdir(config['OutputDir'])
-    if not os.path.isfile('tb_data/csim_results.log'):
-        print("error: build your model with csim before running 'decision_function'")
-        sys.exit() 
+    cmd = 'vivado_hls -f build_prj.tcl "csim=1 synth=0" > predict.log'
+    success = os.system(cmd)
+    if(success > 0):
+        print("'predict' failed, check predict.log")
+        sys.exit()
     y = np.loadtxt('tb_data/csim_results.log')
     if trees:
         tree_scores = np.loadtxt('tb_data/csim_tree_results.log')

--- a/conifer/backends/vivadohls/writer.py
+++ b/conifer/backends/vivadohls/writer.py
@@ -215,8 +215,6 @@ def write(ensemble_dict, cfg):
         # Remove some lines
         elif ('weights' in line) or ('-tb firmware/weights' in line):
             line = ''
-        elif ('cosim_design' in line):
-            line = ''
 
         fout.write(line)
     f.close()

--- a/conifer/backends/vivadohls/writer.py
+++ b/conifer/backends/vivadohls/writer.py
@@ -250,10 +250,11 @@ def decision_function(X, config, trees=False):
 def sim_compile(config):
     return
 
-def build(config):
+def build(config, reset, csim, synth, cosim, export):
     cwd = os.getcwd()
     os.chdir(config['OutputDir'])
-    cmd = 'vivado_hls -f build_prj.tcl'
+    cmd = 'vivado_hls -f build_prj.tcl "reset={reset} csim={csim} synth={synth} cosim={cosim} export={export}"'\
+        .format(reset=reset, csim=csim, synth=synth, cosim=cosim, export=export)
     success = os.system(cmd)
     if(success > 0):
         print("'build' failed")

--- a/conifer/backends/vivadohls/writer.py
+++ b/conifer/backends/vivadohls/writer.py
@@ -233,11 +233,9 @@ def decision_function(X, config, trees=False):
                X, delimiter=",", fmt='%10f')
     cwd = os.getcwd()
     os.chdir(config['OutputDir'])
-    cmd = 'vivado_hls -f build_prj.tcl "csim=1 synth=0" > predict.log'
-    success = os.system(cmd)
-    if(success > 0):
-        print("'predict' failed, check predict.log")
-        sys.exit()
+    if not os.path.isfile('tb_data/csim_results.log'):
+        print("error: build your model with csim before running 'decision_function'")
+        sys.exit() 
     y = np.loadtxt('tb_data/csim_results.log')
     if trees:
         tree_scores = np.loadtxt('tb_data/csim_tree_results.log')
@@ -253,7 +251,7 @@ def sim_compile(config):
 def build(config):
     cwd = os.getcwd()
     os.chdir(config['OutputDir'])
-    cmd = 'vivado_hls -f build_prj.tcl "csim=0 synth=1"'
+    cmd = 'vivado_hls -f build_prj.tcl'
     success = os.system(cmd)
     if(success > 0):
         print("'build' failed")

--- a/conifer/model.py
+++ b/conifer/model.py
@@ -30,8 +30,8 @@ class model:
     def decision_function(self, X, trees=False):
         return self.backend.decision_function(X, self.config, trees=trees)
 
-    def build(self):
-        self.backend.build(self.config)
+    def build(self, reset=False, csim=False, synth=True, cosim=False, export=False):
+        self.backend.build(self.config, reset=reset, csim=csim, synth=synth, cosim=cosim, export=export)
 
     def profile(self, bins=50, return_data=False, return_figure=True):
         try:


### PR DESCRIPTION
There was an issue with running cosim in general since it was not being written in file. I corrected this then followed what hls4ml did [here](https://github.com/hls-fpga-machine-learning/hls4ml/blob/master/hls4ml/model/hls_model.py#L538-L539) to allow users to run reset, csim, synth, cosim, and export by calling an additional parameter in the build() function in the config. The only issues I see currently are that the user can't run csim in the build if it was already run in the decision function previously, and the build.tcl file does not reflect what was actually run since the options in the build function do not change what is in the build.tcl.