### PR TITLE
Add support for Yggdrasil / TensorFlow Decision Forests models

### DIFF
--- a/conifer/converters/__init__.py
+++ b/conifer/converters/__init__.py
@@ -3,6 +3,14 @@ from conifer.converters import sklearn
 from conifer.converters import tmva
 from conifer.converters import xgboost
 from conifer.converters import onnx
+
+try:
+    from conifer.converters import tf_df
+except ImportError:
+    tf_df = None
+    print("Warning: The python package tensorflow_decision_forests is not available. Conversions "
+          "from TensorFlow Decision Forests models is not possible.")
+
 from conifer.model import Model
 import logging
 logger = logging.getLogger(__name__)
@@ -10,7 +18,8 @@ logger = logging.getLogger(__name__)
 _converter_map = {'sklearn' : sklearn,
                   'tmva'    : tmva,
                   'xgboost' : xgboost,
-                  'onnx'    : onnx}
+                  'onnx'    : onnx,
+                  'tf_df':  tf_df}
 
 def get_converter(converter):
   '''Get converter object from string'''
@@ -40,4 +49,9 @@ def convert_from_xgboost(model, config):
 def convert_from_onnx(model, config):
   '''Convert a BDT from an ONNX model and configuration'''
   ensembleDict = onnx.convert(model)
+  return Model(ensembleDict, config)
+
+def convert_from_tf_df(model, config):
+  '''Convert a BDT from an TF-DF model and configuration'''
+  ensembleDict = tf_df.convert(model)
   return Model(ensembleDict, config)

--- a/conifer/converters/tf_df.py
+++ b/conifer/converters/tf_df.py
@@ -1,0 +1,192 @@
+"""Convertion from TensorFlow Decision Forests format."""
+
+from typing import List, Any, Dict
+from conifer.converters.common import addParentAndDepth, padTree
+import tensorflow_decision_forests as tfdf
+
+FeatureMapping = Dict[int, int]
+
+
+def _convert_gbt(inspector: tfdf.inspector.AbstractInspector):
+    """Specialization of "convert" for GBT models."""
+
+    if inspector.task != tfdf.inspector.Task.CLASSIFICATION:
+        raise ValueError("Only classification TF-DF models are supported")
+
+    src_trees = inspector.extract_all_trees()
+
+    # Mapping between the (sparse) column index and a (dense) feature index of the features.
+    column_idx_to_feature_idx = _feature_mapping(inspector)
+
+    # Find the maximum depth of the trees
+    max_depth = _get_max_depth(src_trees)
+
+    # Conifer dictionary without the "trees" field.
+
+    bias = inspector.bias
+    if isinstance(bias, float):
+        bias = [bias]
+    else:
+        bias = bias[:]
+
+    base_conifer_dict = {"max_depth": max_depth,
+                         # Total number of iterations
+                         "n_trees": inspector.num_trees() // inspector.num_trees_per_iter,
+                         # Number of label classes
+                         "n_classes": inspector.objective().num_classes,
+                         # Total number of input features
+                         "n_features": len(inspector. features()),
+                         # Predictions of the model without any trees.
+                         "init_predict": bias,
+                         "norm": 1,
+                         }
+
+    # Converts trees
+    dst_trees = []
+    num_iterations = inspector.num_trees() // inspector.num_trees_per_iter
+
+    for iter_idx in range(num_iterations):
+        dst_trees_per_iter = []
+        for sub_tree_idx in range(inspector.num_trees_per_iter):
+
+            # Converts trees from TF-DF to Conifer format
+            src_tree_idx = sub_tree_idx + iter_idx * inspector.num_trees_per_iter
+            dst_tree = ConiferTree()
+            dst_tree.set_tree(src_trees[src_tree_idx],
+                              column_idx_to_feature_idx)
+
+            # Pad / normalize the trees.
+            dst_tree_dict = padTree(
+                base_conifer_dict, addParentAndDepth(dst_tree.to_dict()))
+            dst_trees_per_iter.append(dst_tree_dict)
+
+        dst_trees.append(dst_trees_per_iter)
+
+    return {**base_conifer_dict, "trees": dst_trees}
+
+
+def _get_max_depth(trees: List[tfdf.py_tree.tree.Tree]) -> int:
+    """Gets the maximum depth of a list of trees."""
+
+    def node_max_depth(node: tfdf.py_tree.node.AbstractNode, depth: int) -> int:
+        if isinstance(node, tfdf.py_tree.node.NonLeafNode):
+            return max(
+                node_max_depth(node.neg_child, depth+1),
+                node_max_depth(node.pos_child, depth+1)
+            )
+
+        return depth
+
+    return max(node_max_depth(tree.root, depth=0) for tree in trees)
+
+
+def _feature_mapping(inspector: tfdf.inspector.AbstractInspector) -> FeatureMapping:
+    """Computes a dense indexing of the TF-DF model "column index".
+
+    TF-DF column index is a possibly sparse indexing of the input features of the model.
+    This method maps the column indices of the input features to [0, m) where m is the
+    number of features.
+    """
+
+    mapping: FeatureMapping = {}
+    for feature in inspector.features():
+        new_index = len(mapping)
+        mapping[feature.col_idx] = new_index
+    return mapping
+
+
+class ConiferTree:
+
+    def __init__(self):
+        self.feature: List[int] = []
+        self.threshold: List[float] = []
+        self.children_left: List[int] = []
+        self.children_right: List[int] = []
+        self.value: List[float] = []
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "feature": self.feature,
+            "threshold": self.threshold,
+            "children_left": self.children_left,
+            "children_right": self.children_right,
+            "value": self.value,
+        }
+
+    def num_nodes(self) -> int:
+        """Number of nodes in the tree."""
+
+        n = len(self.feature)
+        assert n == len(self.threshold)
+        assert n == len(self.children_left)
+        assert n == len(self.children_right)
+        assert n == len(self.value)
+        return n
+
+    def set_tree(self, tree: tfdf.py_tree.tree.Tree, column_idx_to_feature_idx: FeatureMapping) -> None:
+        self._add_node(tree.root, column_idx_to_feature_idx)
+
+    def _add_node(self, node: tfdf.py_tree.node.AbstractNode, column_idx_to_feature_idx: FeatureMapping) -> None:
+
+        if isinstance(node, tfdf.py_tree.node.LeafNode):
+
+            # A leaf node
+            self.feature.append(-2)
+            self.threshold.append(-2.0)
+            self.children_left.append(-1)
+            self.children_right.append(-1)
+
+            if not isinstance(node.value, tfdf.py_tree.value.RegressionValue):
+                raise ValueError(f"No supported leaf type: {node.value}")
+
+            self.value.append(node.value.value)
+
+        elif isinstance(node, tfdf.py_tree.node.NonLeafNode):
+
+            # A non leaf node
+            node_idx = self.num_nodes()
+
+            # Set condition
+            if isinstance(node.condition, tfdf.py_tree.condition.NumericalHigherThanCondition):
+                feature_idx = column_idx_to_feature_idx.get(
+                    node.condition.feature.col_idx)
+                if feature_idx is None:
+                    raise RuntimeError(
+                        f"Unknown feature {node.condition.feature}")
+                self.feature.append(feature_idx)
+                self.threshold.append(node.condition.threshold)
+            else:
+                raise ValueError(
+                    f"No supported TF-DF condition: {node.condition}")
+
+            # Placeholder until the children node indices are computed
+            self.children_left.append(-3)
+            self.children_right.append(-3)
+
+            # Ignored value
+            self.value.append(0)
+
+            # Set children nodes
+            self.children_left[node_idx] = self.num_nodes()
+            self._add_node(node.neg_child, column_idx_to_feature_idx)
+
+            self.children_right[node_idx] = self.num_nodes()
+            self._add_node(node.pos_child, column_idx_to_feature_idx)
+
+        else:
+            raise ValueError("No supported node type")
+
+
+def convert(model: Any) -> Any:
+
+    if isinstance(model, tfdf.inspector.AbstractInspector):
+        # Skip "make_inspector" if the model is already an inspector
+        inspector = model
+    else:
+        inspector = model.make_inspector()
+
+    if inspector.model_type() == "GRADIENT_BOOSTED_TREES":
+        return _convert_gbt(inspector)
+
+    raise ValueError(
+        f"Not supported TF-DF model type {inspector.model_type()}")

--- a/conifer/utils/misc.py
+++ b/conifer/utils/misc.py
@@ -17,7 +17,7 @@ def _ap_include():
       logger.debug(f'Including ap_ headers from {var}: {ret}')
       break
   if ret is None:
-    logger.warn(f'Could not find ap_ headers. None of {", ".join([var[0] for var in variables])} are defined')
+    logger.warn(f'Could not find ap_ headers (e.g., ap_fixed.h). None of {", ".join([var[0] for var in variables])} are defined')
   return ret
 
 def _json_include():

--- a/examples/tf_df_binary.py
+++ b/examples/tf_df_binary.py
@@ -1,0 +1,53 @@
+# Example BDT creation with TensorFlow Decision Forests (https://www.tensorflow.org/decision_forests)
+
+import numpy as np
+import tensorflow_decision_forests as tfdf
+from sklearn.datasets import make_hastie_10_2
+import conifer
+import datetime
+import logging
+import sys
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
+# Create dataset
+X, y = make_hastie_10_2(random_state=0)
+
+# Train a BDT
+model = tfdf.keras.GradientBoostedTreesModel(
+    num_trees=1, max_depth=2, verbose=0, apply_link_function=False)
+model.fit(x=X, y=y)
+
+stamp = int(datetime.datetime.now().timestamp())
+# Create a conifer config
+cpp_cfg = conifer.backends.cpp.auto_config()
+#cpp_cfg["Precision"] = "float"
+# Set the output directory to something unique
+cpp_cfg['OutputDir'] = 'prj_cpp_{}'.format(stamp)
+
+# Create and compile the model
+cpp_model = conifer.converters.convert_from_tf_df(model, cpp_cfg)
+cpp_model.compile()
+
+# Create a conifer config
+hls_cfg = conifer.backends.xilinxhls.auto_config()
+#hls_cfg["Precision"] = "float"
+# Set the output directory to something unique
+hls_cfg['OutputDir'] = 'prj_hls_{}'.format(stamp)
+
+# Create and compile the model
+hls_model = conifer.converters.convert_from_tf_df(model, hls_cfg)
+hls_model.compile()
+
+# Run the C++ and get the output
+y_cpp = cpp_model.decision_function(X)
+y_hls = hls_model.decision_function(X)
+y_skl = model.predict(X, verbose=0)[:, 0]
+
+if np.array_equal(y_hls, y_cpp):
+    print(f'HLS and CPP predictions agree 100% ({len(y_cpp)}/{len(y_cpp)})')
+else:
+    abs_diff = np.abs(y_hls - y_cpp)
+    rel_diff = abs_diff / np.abs(y_hls)
+    print(
+        f'HLS and CPP predictions disagree. Biggest absolute difference: {abs_diff.max():.4f}, biggest relative difference: {rel_diff.max():.4f}')

--- a/examples/tf_df_multiclass.py
+++ b/examples/tf_df_multiclass.py
@@ -1,0 +1,54 @@
+# Example BDT creation with TensorFlow Decision Forests (https://www.tensorflow.org/decision_forests)
+
+import numpy as np
+import tensorflow_decision_forests as tfdf
+from sklearn.datasets import load_iris
+import conifer
+import datetime
+import logging
+import sys
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
+# Create dataset
+iris = load_iris()
+X, y = iris.data, iris.target
+
+# Train a BDT
+model = tfdf.keras.GradientBoostedTreesModel(
+    num_trees=100, max_depth=6, verbose=0)
+model.fit(x=X, y=y)
+
+stamp = int(datetime.datetime.now().timestamp())
+# Create a conifer config
+cpp_cfg = conifer.backends.cpp.auto_config()
+#cpp_cfg["Precision"] = "float"
+# Set the output directory to something unique
+cpp_cfg['OutputDir'] = 'prj_cpp_{}'.format(stamp)
+
+# Create and compile the model
+cpp_model = conifer.converters.convert_from_tf_df(model, cpp_cfg)
+cpp_model.compile()
+
+# Create a conifer config
+hls_cfg = conifer.backends.xilinxhls.auto_config()
+#hls_cfg["Precision"] = "float"
+# Set the output directory to something unique
+hls_cfg['OutputDir'] = 'prj_hls_{}'.format(stamp)
+
+# Create and compile the model
+hls_model = conifer.converters.convert_from_tf_df(model, hls_cfg)
+hls_model.compile()
+
+# Run the C++ and get the output
+y_cpp = cpp_model.decision_function(X)
+y_hls = hls_model.decision_function(X)
+y_skl = model.predict(X, verbose=0)
+
+if np.array_equal(y_hls, y_cpp):
+    print(f'HLS and CPP predictions agree 100% ({len(y_cpp)}/{len(y_cpp)})')
+else:
+    abs_diff = np.abs(y_hls - y_cpp)
+    rel_diff = abs_diff / np.abs(y_hls)
+    print(
+        f'HLS and CPP predictions disagree. Biggest absolute difference: {abs_diff.max():.4f}, biggest relative difference: {rel_diff.max():.4f}')

--- a/tests/test_tf_df.py
+++ b/tests/test_tf_df.py
@@ -1,0 +1,157 @@
+import pytest
+import numpy as np
+from typing import Tuple
+import tensorflow_decision_forests as tfdf
+
+
+@pytest.fixture(params=["hastie", "iris"])
+def build_dataset(request) -> Tuple[np.array, np.array, np.array]:
+
+    if request.param == "hastie":
+        from sklearn.datasets import make_hastie_10_2
+        X, y = make_hastie_10_2(random_state=0, n_samples=4000)
+        return X[:2000], y[:2000], X[2000:]
+
+    elif request.param == "iris":
+
+        from sklearn.datasets import load_iris
+        iris = load_iris()
+        return iris.data, iris.target, iris.data
+
+    else:
+        raise ValueError("Unknown dataset")
+
+
+@pytest.fixture
+def build_tf_df_model(build_dataset) -> tfdf.keras.CoreModel:
+
+    X, y, _ = build_dataset
+
+    tf_df_model = tfdf.keras.GradientBoostedTreesModel(
+        num_trees=20, max_depth=6, verbose=0, apply_link_function=False)
+    tf_df_model.fit(x=X, y=y)
+
+    return tf_df_model
+
+
+@pytest.fixture
+def hls_convert(build_tf_df_model, tmp_path):
+    import conifer
+
+    tf_df_model = build_tf_df_model
+
+    # Create a conifer config
+    cfg = conifer.backends.xilinxhls.auto_config()
+    cfg["Precision"] = "ap_fixed<32,16,AP_RND,AP_SAT>"
+    # Set the output directory to something unique
+    cfg["OutputDir"] = str(tmp_path)
+    cfg["XilinxPart"] = "xcu250-figd2104-2L-e"
+
+    # Create and compile the model
+    model = conifer.converters.convert_from_tf_df(tf_df_model, cfg)
+    model.compile()
+    return model
+
+
+@pytest.fixture
+def vhdl_convert(build_tf_df_model, tmp_path):
+    import conifer
+
+    tf_df_model = build_tf_df_model
+
+    # Create a conifer config
+    cfg = conifer.backends.vhdl.auto_config()
+    cfg["Precision"] = "ap_fixed<32,16>"
+    # Set the output directory to something unique
+    cfg["OutputDir"] = str(tmp_path)
+    cfg["XilinxPart"] = "xcu250-figd2104-2L-e"
+
+    # Create and compile the model
+    model = conifer.converters.convert_from_tf_df(tf_df_model, cfg)
+    model.compile()
+    return model
+
+
+def test_toy_model(tmp_path):
+    import conifer
+
+    tf_df_path = str(tmp_path / "model")
+    builder = tfdf.builder.GradientBoostedTreeBuilder(
+        path=tf_df_path,
+        bias=1.0,
+        model_format=tfdf.builder.ModelFormat.YGGDRASIL_DECISION_FOREST,
+        objective=tfdf.py_tree.objective.ClassificationObjective(
+            label="color", classes=["red", "blue"]))
+
+    #  f0>=1.5
+    #    ├─(pos)─ f1>=2.5
+    #    │         ├─(pos)─ value: 0.8
+    #    │         └─(neg)─ value: 0.6
+    #    └─(neg)─ value: 0.1
+
+    Tree = tfdf.py_tree.tree.Tree
+    NonLeafNode = tfdf.py_tree.node.NonLeafNode
+    NumericalHigherThanCondition = tfdf.py_tree.condition.NumericalHigherThanCondition
+    SimpleColumnSpec = tfdf.py_tree.dataspec.SimpleColumnSpec
+    LeafNode = tfdf.py_tree.node.LeafNode
+    RegressionValue = tfdf.py_tree.value.RegressionValue
+    ColumnType = tfdf.py_tree.dataspec.ColumnType
+
+    builder.add_tree(
+        Tree(NonLeafNode(
+            condition=NumericalHigherThanCondition(
+                feature=SimpleColumnSpec(name="f0", type=ColumnType.NUMERICAL),
+                threshold=1.5,
+                missing_evaluation=False),
+            pos_child=NonLeafNode(
+                condition=NumericalHigherThanCondition(
+                    feature=SimpleColumnSpec(
+                        name="f1", type=ColumnType.NUMERICAL),
+                    threshold=2.5,
+                    missing_evaluation=False),
+                pos_child=LeafNode(value=RegressionValue(value=0.8)),
+                neg_child=LeafNode(value=RegressionValue(value=0.6))),
+            neg_child=LeafNode(value=RegressionValue(value=0.1)))))
+    builder.close()
+
+    inspector = tfdf.inspector.make_inspector(tf_df_path)
+
+    cfg = conifer.backends.xilinxhls.auto_config()
+    conifer_model = conifer.converters.tf_df.convert(inspector)
+
+    assert conifer_model == {"max_depth": 2,
+                             "n_trees": 1,
+                             "n_classes": 2,
+                             "n_features": 2,
+                             "init_predict": [1.0],
+                             "norm": 1,
+                             "trees": [[{"feature": [0, -2, 1, -2, -2, -2, -2],
+                                         "threshold": pytest.approx([1.5, -2.0, 2.5, -2.0, -2.0, -2.0, -2.0]),
+                                         "children_left": [1, 5, 3, -1, -1, -1, -1],
+                                         "children_right": [2, 6, 4, -1, -1, -1, -1],
+                                         "value": pytest.approx([0, 0.1, 0, 0.6, 0.8, 0.1, 0.1]),
+                                         "parent": [-1, 0, 0, 2, 2, 1, 1],
+                                         "depth": [0, 1, 1, 2, 2, 2, 2],
+                                         "iLeaf": [3, 4, 5, 6]}
+                                        ]]
+                             }
+
+
+def test_build_vhdl(vhdl_convert):
+    # TODO: Check equality of predictions.
+    _ = vhdl_convert
+    assert True
+
+
+def test_predict_hls(hls_convert, build_tf_df_model, build_dataset):
+
+    import numpy as np
+
+    _, _, X = build_dataset
+    hls_model = hls_convert
+    tf_df_model = build_tf_df_model
+
+    hls_pred = hls_model.decision_function(X)
+    tf_df_pred = np.squeeze(tf_df_model.predict(X))
+
+    assert np.all(np.isclose(hls_pred, tf_df_pred, rtol=1e-2, atol=1e-2))


### PR DESCRIPTION
Following this change, a subset of Yggdrasil / TensorFlow Decision Forests models can be imported to and compiled by Conifer. This change supports Classification (binary and multi-class) Gradient Boosted Trees with feature>=threshold conditions.