### PR TITLE
Add simulator discovery to VHDL backend

### DIFF
--- a/conifer/backends/vhdl/__init__.py
+++ b/conifer/backends/vhdl/__init__.py
@@ -1,3 +1,11 @@
 from conifer.backends.vhdl.writer import make_model, auto_config
 from conifer.backends.vhdl.simulators import Modelsim, GHDL, Xsim
 simulator = Xsim
+import logging
+logger = logging.getLogger(__name__)
+for sim in [Xsim, GHDL, Modelsim]:
+  from conifer.backends.vhdl.simulators import _touch
+  if _touch(sim):
+    logger.info(f'Found {sim.__name__}, setting VHDL simulator to {sim.__name__}')
+    simulator = sim
+    break

--- a/conifer/backends/vhdl/scripts/ghdl_compile.sh
+++ b/conifer/backends/vhdl/scripts/ghdl_compile.sh
@@ -1,0 +1,15 @@
+ghdl -a --std=08 --work=BDT ./firmware/Constants.vhd
+ghdl -a --std=08 --work=BDT ./firmware/Types.vhd
+ghdl -a --std=08 --work=BDT ./firmware/Tree.vhd
+ghdl -a --std=08 --work=BDT ./firmware/AddReduce.vhd
+
+# insert arrays
+
+ghdl -a --std=08 --work=BDT ./firmware/BDT.vhd
+ghdl -a --std=08 --work=BDT ./firmware/BDTTop.vhd
+
+ghdl -a --std=08 --work=xil_defaultlib ./firmware/SimulationInput.vhd
+ghdl -a --std=08 --work=xil_defaultlib ./firmware/SimulationOutput.vhd
+ghdl -a --std=08 --work=xil_defaultlib ./firmware/BDTTestbench.vhd
+
+ghdl -e --std=08 --work=xil_defaultlib testbench

--- a/conifer/backends/vhdl/simulators.py
+++ b/conifer/backends/vhdl/simulators.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import logging
 logger = logging.getLogger(__name__)
 
@@ -25,7 +26,16 @@ def _run_sim(simulator, odir):
       logger.error(f"'sim_compile' failed, check {simulator.__name__.lower()}.log")
     return success == 0
 
+def _touch(simulator):
+  cmd = simulator._touch_cmd
+  try:
+    success = subprocess.call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+  except:
+    success = 1
+  return success == 0
+
 class Modelsim:
+  _touch_cmd = ['vsim', '-c', '-do', 'quit -f']
   _compile_cmd = 'sh modelsim_compile.sh > modelsim_compile.log'
   _run_cmd = 'vsim -c -do "vsim -L BDT -L xil_defaultlib xil_defaultlib.testbench; run -all; quit -f" > vsim.log'
   
@@ -55,6 +65,7 @@ class Modelsim:
     return _run_sim(Modelsim, odir)
 
 class GHDL:
+  _touch_cmd = ['ghdl', '--version']
   _compile_cmd = 'sh ghdl_compile.sh > ghdl_compile.log'
   _run_cmd = 'ghdl -r --std=08 --work=xil_defaultlib testbench > ghdl.log'
   def write_scripts(outputdir, filedir, n_classes):
@@ -77,6 +88,7 @@ class GHDL:
     return _run_sim(GHDL, odir)
 
 class Xsim:
+  _touch_cmd = ['xsim', '--version']
   _compile_cmd = 'sh xsim_compile.sh > xsim_compile.log'
   _run_cmd = 'xsim -R bdt_tb > xsim.log'
   def write_scripts(outputdir, filedir, n_classes):


### PR DESCRIPTION
The VHDL backend supports three simulators: Vivado XSim, GHDL, and Modelsim, defaulting to XSim.  This PR changes the initialisation such that on `import conifer`, we probe which simulators are available and set the default to the first one that is available, in order of preference: Xsim, GHDL, Modelsim. 

The user can still control which simulator to target like `conifer.backends.vhdl.simulator = conifer.backends.vhdl.simulators.GHDL`, in case they have several available and prefer a different one to the default.

This PR also adds the GHDL compile script, which was accidentally missing.