### PR TITLE
Manually unrolled HLS

### DIFF
--- a/conifer/backends/xilinxhls/firmware/BDT_rolled.h
+++ b/conifer/backends/xilinxhls/firmware/BDT_rolled.h
@@ -28,83 +28,83 @@ private:
   static constexpr int n_nodes = fn_nodes(max_depth);
   static constexpr int n_leaves = fn_leaves(max_depth);
 public:
-	int feature[n_nodes];
-	threshold_t threshold[n_nodes];
-	score_t value[n_nodes];
-	int children_left[n_nodes];
-	int children_right[n_nodes];
-	int parent[n_nodes];
+  int feature[n_nodes];
+  threshold_t threshold[n_nodes];
+  score_t value[n_nodes];
+  int children_left[n_nodes];
+  int children_right[n_nodes];
+  int parent[n_nodes];
 
-	score_t decision_function(input_t x) const{
-		#pragma HLS pipeline II = 1
-		#pragma HLS ARRAY_PARTITION variable=feature
-		#pragma HLS ARRAY_PARTITION variable=threshold
-		#pragma HLS ARRAY_PARTITION variable=value
-		#pragma HLS ARRAY_PARTITION variable=children_left
-		#pragma HLS ARRAY_PARTITION variable=children_right
-		#pragma HLS ARRAY_PARTITION variable=parent
+  score_t decision_function(input_t x) const{
+    #pragma HLS pipeline II = 1
+    #pragma HLS ARRAY_PARTITION variable=feature
+    #pragma HLS ARRAY_PARTITION variable=threshold
+    #pragma HLS ARRAY_PARTITION variable=value
+    #pragma HLS ARRAY_PARTITION variable=children_left
+    #pragma HLS ARRAY_PARTITION variable=children_right
+    #pragma HLS ARRAY_PARTITION variable=parent
     // These resource pragmas prevent the array of trees from being partitioned
     // They should be unnecessary anyway due to their own partitioning above
-		/*#pragma HLS RESOURCE variable=feature core=ROM_nP_LUTRAM
-		#pragma HLS RESOURCE variable=threshold core=ROM_nP_LUTRAM
-		#pragma HLS RESOURCE variable=value core=ROM_nP_LUTRAM
-		#pragma HLS RESOURCE variable=children_left core=ROM_nP_LUTRAM
-		#pragma HLS RESOURCE variable=children_right core=ROM_nP_LUTRAM
-		#pragma HLS RESOURCE variable=parent core=ROM_nP_LUTRAM*/
+    /*#pragma HLS RESOURCE variable=feature core=ROM_nP_LUTRAM
+    #pragma HLS RESOURCE variable=threshold core=ROM_nP_LUTRAM
+    #pragma HLS RESOURCE variable=value core=ROM_nP_LUTRAM
+    #pragma HLS RESOURCE variable=children_left core=ROM_nP_LUTRAM
+    #pragma HLS RESOURCE variable=children_right core=ROM_nP_LUTRAM
+    #pragma HLS RESOURCE variable=parent core=ROM_nP_LUTRAM*/
 
-		bool comparison[n_nodes];
-		bool activation[n_nodes];
-		bool activation_leaf[n_leaves];
-		score_t value_leaf[n_leaves];
+    bool comparison[n_nodes];
+    bool activation[n_nodes];
+    bool activation_leaf[n_leaves];
+    score_t value_leaf[n_leaves];
 
-		#pragma HLS ARRAY_PARTITION variable=comparison
-		#pragma HLS ARRAY_PARTITION variable=activation
-		#pragma HLS ARRAY_PARTITION variable=activation_leaf
-		#pragma HLS ARRAY_PARTITION variable=value_leaf
+    #pragma HLS ARRAY_PARTITION variable=comparison
+    #pragma HLS ARRAY_PARTITION variable=activation
+    #pragma HLS ARRAY_PARTITION variable=activation_leaf
+    #pragma HLS ARRAY_PARTITION variable=value_leaf
 
-		// Execute all comparisons
-		Compare: for(int i = 0; i < n_nodes; i++){
-			#pragma HLS unroll
-			// Only non-leaf nodes do comparisons
-			// negative values mean is a leaf (sklearn: -2)
-			if(feature[i] >= 0){
-				comparison[i] = x[feature[i]] <= threshold[i];
-			}else{
-				comparison[i] = true;
-			}
-		}
+    // Execute all comparisons
+    Compare: for(int i = 0; i < n_nodes; i++){
+      #pragma HLS unroll
+      // Only non-leaf nodes do comparisons
+      // negative values mean is a leaf (sklearn: -2)
+      if(feature[i] >= 0){
+        comparison[i] = x[feature[i]] <= threshold[i];
+      }else{
+        comparison[i] = true;
+      }
+    }
 
-		// Determine node activity for all nodes
-		int iLeaf = 0;
-		Activate: for(int i = 0; i < n_nodes; i++){
-			#pragma HLS unroll
-			// Root node is always active
-			if(i == 0){
-				activation[i] = true;
-			}else{
-				// If this node is the left child of its parent
-				if(i == children_left[parent[i]]){
-					activation[i] = comparison[parent[i]] && activation[parent[i]];
-				}else{ // Else it is the right child
-					activation[i] = !comparison[parent[i]] && activation[parent[i]];
-				}
-			}
-			// Skim off the leaves
-			if(children_left[i] == -1){ // is a leaf
-				activation_leaf[iLeaf] = activation[i];
-				value_leaf[iLeaf] = value[i];
-				iLeaf++;
-			}
-		}
+    // Determine node activity for all nodes
+    int iLeaf = 0;
+    Activate: for(int i = 0; i < n_nodes; i++){
+      #pragma HLS unroll
+      // Root node is always active
+      if(i == 0){
+        activation[i] = true;
+      }else{
+        // If this node is the left child of its parent
+        if(i == children_left[parent[i]]){
+          activation[i] = comparison[parent[i]] && activation[parent[i]];
+        }else{ // Else it is the right child
+          activation[i] = !comparison[parent[i]] && activation[parent[i]];
+        }
+      }
+      // Skim off the leaves
+      if(children_left[i] == -1){ // is a leaf
+        activation_leaf[iLeaf] = activation[i];
+        value_leaf[iLeaf] = value[i];
+        iLeaf++;
+      }
+    }
 
-		score_t y = 0;
-		for(int i = 0; i < n_leaves; i++){
-			if(activation_leaf[i]){
-				return value_leaf[i];
-			}
-		}
-		return y;
-	}
+    score_t y = 0;
+    for(int i = 0; i < n_leaves; i++){
+      if(activation_leaf[i]){
+        return value_leaf[i];
+      }
+    }
+    return y;
+  }
 };
 
 template<int n_trees, int max_depth, int n_classes, class input_t, class score_t, class threshold_t, bool unroll>
@@ -112,33 +112,33 @@ struct BDT{
 
 public:
   score_t normalisation;
-	score_t init_predict[fn_classes(n_classes)];
-	Tree<max_depth, input_t, score_t, threshold_t> trees[n_trees][fn_classes(n_classes)];
+  score_t init_predict[fn_classes(n_classes)];
+  Tree<max_depth, input_t, score_t, threshold_t> trees[n_trees][fn_classes(n_classes)];
 
-	void tree_scores(input_t x, score_t scores[n_trees][fn_classes(n_classes)]) const;
+  void tree_scores(input_t x, score_t scores[n_trees][fn_classes(n_classes)]) const;
 
-	void decision_function(input_t x, score_t score[fn_classes(n_classes)]) const{
-		score_t scores[n_trees][fn_classes(n_classes)];
-		if(unroll){
-			#pragma HLS ARRAY_PARTITION variable=trees dim=0
-			#pragma HLS ARRAY_PARTITION variable=scores dim=0
-			#pragma HLS PIPELINE
-		}
-		for(int j = 0; j < fn_classes(n_classes); j++){
-			score[j] = init_predict[j];
-		}
-		tree_scores(x, scores);
-		Trees:
-		for(int i = 0; i < n_trees; i++){
-			Classes:
-			for(int j = 0; j < fn_classes(n_classes); j++){
-				score[j] += scores[i][j];
-			}
-		}
-		for(int j = 0; j < fn_classes(n_classes); j++){
-			score[j] *= normalisation;
-		}
-	}
+  void decision_function(input_t x, score_t score[fn_classes(n_classes)]) const{
+    score_t scores[n_trees][fn_classes(n_classes)];
+    if(unroll){
+      #pragma HLS ARRAY_PARTITION variable=trees dim=0
+      #pragma HLS ARRAY_PARTITION variable=scores dim=0
+      #pragma HLS PIPELINE
+    }
+    for(int j = 0; j < fn_classes(n_classes); j++){
+      score[j] = init_predict[j];
+    }
+    tree_scores(x, scores);
+    Trees:
+    for(int i = 0; i < n_trees; i++){
+      Classes:
+      for(int j = 0; j < fn_classes(n_classes); j++){
+        score[j] += scores[i][j];
+      }
+    }
+    for(int j = 0; j < fn_classes(n_classes); j++){
+      score[j] *= normalisation;
+    }
+  }
 
 };
 

--- a/conifer/backends/xilinxhls/firmware/BDT_unrolled.h
+++ b/conifer/backends/xilinxhls/firmware/BDT_unrolled.h
@@ -1,0 +1,127 @@
+#ifndef BDT_H__
+#define BDT_H__
+
+#include "ap_fixed.h"
+
+namespace BDT{
+
+constexpr int fn_classes(int n_classes){
+  // Number of trees given number of classes
+  return n_classes == 2 ? 1 : n_classes;
+}
+
+template<int n_tree, int n_nodes, int n_leaves, class input_t, class score_t, class threshold_t>
+struct Tree {
+private:
+public:
+	int feature[n_nodes];
+	threshold_t threshold[n_nodes];
+	score_t value[n_nodes];
+	int children_left[n_nodes];
+	int children_right[n_nodes];
+	int parent[n_nodes];
+
+	score_t decision_function(input_t x) const{
+		#pragma HLS pipeline II = 1
+		#pragma HLS ARRAY_PARTITION variable=feature
+		#pragma HLS ARRAY_PARTITION variable=threshold
+		#pragma HLS ARRAY_PARTITION variable=value
+		#pragma HLS ARRAY_PARTITION variable=children_left
+		#pragma HLS ARRAY_PARTITION variable=children_right
+		#pragma HLS ARRAY_PARTITION variable=parent
+    // These resource pragmas prevent the array of trees from being partitioned
+    // They should be unnecessary anyway due to their own partitioning above
+		/*#pragma HLS RESOURCE variable=feature core=ROM_nP_LUTRAM
+		#pragma HLS RESOURCE variable=threshold core=ROM_nP_LUTRAM
+		#pragma HLS RESOURCE variable=value core=ROM_nP_LUTRAM
+		#pragma HLS RESOURCE variable=children_left core=ROM_nP_LUTRAM
+		#pragma HLS RESOURCE variable=children_right core=ROM_nP_LUTRAM
+		#pragma HLS RESOURCE variable=parent core=ROM_nP_LUTRAM*/
+
+		bool comparison[n_nodes];
+		bool activation[n_nodes];
+		bool activation_leaf[n_leaves];
+		score_t value_leaf[n_leaves];
+
+		#pragma HLS ARRAY_PARTITION variable=comparison
+		#pragma HLS ARRAY_PARTITION variable=activation
+		#pragma HLS ARRAY_PARTITION variable=activation_leaf
+		#pragma HLS ARRAY_PARTITION variable=value_leaf
+
+		// Execute all comparisons
+		Compare: for(int i = 0; i < n_nodes; i++){
+			#pragma HLS unroll
+			// Only non-leaf nodes do comparisons
+			// negative values mean is a leaf (sklearn: -2)
+			if(feature[i] >= 0){
+				comparison[i] = x[feature[i]] <= threshold[i];
+			}else{
+				comparison[i] = true;
+			}
+		}
+
+		// Determine node activity for all nodes
+		int iLeaf = 0;
+		Activate: for(int i = 0; i < n_nodes; i++){
+			#pragma HLS unroll
+			// Root node is always active
+			if(i == 0){
+				activation[i] = true;
+			}else{
+				// If this node is the left child of its parent
+				if(i == children_left[parent[i]]){
+					activation[i] = comparison[parent[i]] && activation[parent[i]];
+				}else{ // Else it is the right child
+					activation[i] = !comparison[parent[i]] && activation[parent[i]];
+				}
+			}
+			// Skim off the leaves
+			if(children_left[i] == -1){ // is a leaf
+				activation_leaf[iLeaf] = activation[i];
+				value_leaf[iLeaf] = value[i];
+				iLeaf++;
+			}
+		}
+
+		score_t y = 0;
+		for(int i = 0; i < n_leaves; i++){
+			if(activation_leaf[i]){
+				return value_leaf[i];
+			}
+		}
+		return y;
+	}
+};
+
+template<int n_trees, int n_classes, class input_t, class score_t, class threshold_t>
+struct BDT{
+
+public:
+  score_t normalisation;
+	score_t init_predict[fn_classes(n_classes)];
+
+	void tree_scores(input_t x, score_t scores[n_trees][fn_classes(n_classes)]) const;
+
+	void decision_function(input_t x, score_t score[fn_classes(n_classes)]) const{
+		score_t scores[n_trees][fn_classes(n_classes)];
+		#pragma HLS ARRAY_PARTITION variable=scores dim=0
+		for(int j = 0; j < fn_classes(n_classes); j++){
+			score[j] = init_predict[j];
+		}
+		tree_scores(x, scores);
+		Trees:
+		for(int i = 0; i < n_trees; i++){
+			Classes:
+			for(int j = 0; j < fn_classes(n_classes); j++){
+				score[j] += scores[i][j];
+			}
+		}
+		for(int j = 0; j < fn_classes(n_classes); j++){
+			score[j] *= normalisation;
+		}
+	}
+
+};
+
+}
+#endif

--- a/conifer/backends/xilinxhls/firmware/BDT_unrolled.h
+++ b/conifer/backends/xilinxhls/firmware/BDT_unrolled.h
@@ -14,83 +14,83 @@ template<int n_tree, int n_nodes, int n_leaves, class input_t, class score_t, cl
 struct Tree {
 private:
 public:
-	int feature[n_nodes];
-	threshold_t threshold[n_nodes];
-	score_t value[n_nodes];
-	int children_left[n_nodes];
-	int children_right[n_nodes];
-	int parent[n_nodes];
+  int feature[n_nodes];
+  threshold_t threshold[n_nodes];
+  score_t value[n_nodes];
+  int children_left[n_nodes];
+  int children_right[n_nodes];
+  int parent[n_nodes];
 
-	score_t decision_function(input_t x) const{
-		#pragma HLS pipeline II = 1
-		#pragma HLS ARRAY_PARTITION variable=feature
-		#pragma HLS ARRAY_PARTITION variable=threshold
-		#pragma HLS ARRAY_PARTITION variable=value
-		#pragma HLS ARRAY_PARTITION variable=children_left
-		#pragma HLS ARRAY_PARTITION variable=children_right
-		#pragma HLS ARRAY_PARTITION variable=parent
+  score_t decision_function(input_t x) const{
+    #pragma HLS pipeline II = 1
+    #pragma HLS ARRAY_PARTITION variable=feature
+    #pragma HLS ARRAY_PARTITION variable=threshold
+    #pragma HLS ARRAY_PARTITION variable=value
+    #pragma HLS ARRAY_PARTITION variable=children_left
+    #pragma HLS ARRAY_PARTITION variable=children_right
+    #pragma HLS ARRAY_PARTITION variable=parent
     // These resource pragmas prevent the array of trees from being partitioned
     // They should be unnecessary anyway due to their own partitioning above
-		/*#pragma HLS RESOURCE variable=feature core=ROM_nP_LUTRAM
-		#pragma HLS RESOURCE variable=threshold core=ROM_nP_LUTRAM
-		#pragma HLS RESOURCE variable=value core=ROM_nP_LUTRAM
-		#pragma HLS RESOURCE variable=children_left core=ROM_nP_LUTRAM
-		#pragma HLS RESOURCE variable=children_right core=ROM_nP_LUTRAM
-		#pragma HLS RESOURCE variable=parent core=ROM_nP_LUTRAM*/
+    /*#pragma HLS RESOURCE variable=feature core=ROM_nP_LUTRAM
+    #pragma HLS RESOURCE variable=threshold core=ROM_nP_LUTRAM
+    #pragma HLS RESOURCE variable=value core=ROM_nP_LUTRAM
+    #pragma HLS RESOURCE variable=children_left core=ROM_nP_LUTRAM
+    #pragma HLS RESOURCE variable=children_right core=ROM_nP_LUTRAM
+    #pragma HLS RESOURCE variable=parent core=ROM_nP_LUTRAM*/
 
-		bool comparison[n_nodes];
-		bool activation[n_nodes];
-		bool activation_leaf[n_leaves];
-		score_t value_leaf[n_leaves];
+    bool comparison[n_nodes];
+    bool activation[n_nodes];
+    bool activation_leaf[n_leaves];
+    score_t value_leaf[n_leaves];
 
-		#pragma HLS ARRAY_PARTITION variable=comparison
-		#pragma HLS ARRAY_PARTITION variable=activation
-		#pragma HLS ARRAY_PARTITION variable=activation_leaf
-		#pragma HLS ARRAY_PARTITION variable=value_leaf
+    #pragma HLS ARRAY_PARTITION variable=comparison
+    #pragma HLS ARRAY_PARTITION variable=activation
+    #pragma HLS ARRAY_PARTITION variable=activation_leaf
+    #pragma HLS ARRAY_PARTITION variable=value_leaf
 
-		// Execute all comparisons
-		Compare: for(int i = 0; i < n_nodes; i++){
-			#pragma HLS unroll
-			// Only non-leaf nodes do comparisons
-			// negative values mean is a leaf (sklearn: -2)
-			if(feature[i] >= 0){
-				comparison[i] = x[feature[i]] <= threshold[i];
-			}else{
-				comparison[i] = true;
-			}
-		}
+    // Execute all comparisons
+    Compare: for(int i = 0; i < n_nodes; i++){
+      #pragma HLS unroll
+      // Only non-leaf nodes do comparisons
+      // negative values mean is a leaf (sklearn: -2)
+      if(feature[i] >= 0){
+        comparison[i] = x[feature[i]] <= threshold[i];
+      }else{
+        comparison[i] = true;
+      }
+    }
 
-		// Determine node activity for all nodes
-		int iLeaf = 0;
-		Activate: for(int i = 0; i < n_nodes; i++){
-			#pragma HLS unroll
-			// Root node is always active
-			if(i == 0){
-				activation[i] = true;
-			}else{
-				// If this node is the left child of its parent
-				if(i == children_left[parent[i]]){
-					activation[i] = comparison[parent[i]] && activation[parent[i]];
-				}else{ // Else it is the right child
-					activation[i] = !comparison[parent[i]] && activation[parent[i]];
-				}
-			}
-			// Skim off the leaves
-			if(children_left[i] == -1){ // is a leaf
-				activation_leaf[iLeaf] = activation[i];
-				value_leaf[iLeaf] = value[i];
-				iLeaf++;
-			}
-		}
+    // Determine node activity for all nodes
+    int iLeaf = 0;
+    Activate: for(int i = 0; i < n_nodes; i++){
+      #pragma HLS unroll
+      // Root node is always active
+      if(i == 0){
+        activation[i] = true;
+      }else{
+        // If this node is the left child of its parent
+        if(i == children_left[parent[i]]){
+          activation[i] = comparison[parent[i]] && activation[parent[i]];
+        }else{ // Else it is the right child
+          activation[i] = !comparison[parent[i]] && activation[parent[i]];
+        }
+      }
+      // Skim off the leaves
+      if(children_left[i] == -1){ // is a leaf
+        activation_leaf[iLeaf] = activation[i];
+        value_leaf[iLeaf] = value[i];
+        iLeaf++;
+      }
+    }
 
-		score_t y = 0;
-		for(int i = 0; i < n_leaves; i++){
-			if(activation_leaf[i]){
-				return value_leaf[i];
-			}
-		}
-		return y;
-	}
+    score_t y = 0;
+    for(int i = 0; i < n_leaves; i++){
+      if(activation_leaf[i]){
+        return value_leaf[i];
+      }
+    }
+    return y;
+  }
 };
 
 template<int n_trees, int n_classes, class input_t, class score_t, class threshold_t>
@@ -98,28 +98,28 @@ struct BDT{
 
 public:
   score_t normalisation;
-	score_t init_predict[fn_classes(n_classes)];
+  score_t init_predict[fn_classes(n_classes)];
 
-	void tree_scores(input_t x, score_t scores[n_trees][fn_classes(n_classes)]) const;
+  void tree_scores(input_t x, score_t scores[n_trees][fn_classes(n_classes)]) const;
 
-	void decision_function(input_t x, score_t score[fn_classes(n_classes)]) const{
-		score_t scores[n_trees][fn_classes(n_classes)];
-		#pragma HLS ARRAY_PARTITION variable=scores dim=0
-		for(int j = 0; j < fn_classes(n_classes); j++){
-			score[j] = init_predict[j];
-		}
-		tree_scores(x, scores);
-		Trees:
-		for(int i = 0; i < n_trees; i++){
-			Classes:
-			for(int j = 0; j < fn_classes(n_classes); j++){
-				score[j] += scores[i][j];
-			}
-		}
-		for(int j = 0; j < fn_classes(n_classes); j++){
-			score[j] *= normalisation;
-		}
-	}
+  void decision_function(input_t x, score_t score[fn_classes(n_classes)]) const{
+    score_t scores[n_trees][fn_classes(n_classes)];
+    #pragma HLS ARRAY_PARTITION variable=scores dim=0
+    for(int j = 0; j < fn_classes(n_classes); j++){
+      score[j] = init_predict[j];
+    }
+    tree_scores(x, scores);
+    Trees:
+    for(int i = 0; i < n_trees; i++){
+      Classes:
+      for(int j = 0; j < fn_classes(n_classes); j++){
+        score[j] += scores[i][j];
+      }
+    }
+    for(int j = 0; j < fn_classes(n_classes); j++){
+      score[j] *= normalisation;
+    }
+  }
 
 };
 

--- a/conifer/backends/xilinxhls/hls-template/bridge.cpp
+++ b/conifer/backends/xilinxhls/hls-template/bridge.cpp
@@ -13,9 +13,8 @@ std::vector<double> decision_function(std::vector<double> x){
   std::copy(xtv.begin(), xtv.end(), xt);
 
   score_t yt[BDT::fn_classes(n_classes)];
-  score_t tree_scores[BDT::fn_classes(n_classes) * n_trees];
 
-  bdt.decision_function(xt, yt, tree_scores);
+  bdt.decision_function(xt, yt);
   std::vector<score_t> ytv(yt, yt + BDT::fn_classes(n_classes));
   std::vector<double> yd;
   std::transform(ytv.begin(), ytv.end(), std::back_inserter(yd),

--- a/conifer/backends/xilinxhls/hls-template/build_prj.tcl
+++ b/conifer/backends/xilinxhls/hls-template/build_prj.tcl
@@ -27,6 +27,7 @@ if {$opt(reset)} {
 
 set_top myproject
 add_files firmware/BDT.h -cflags "-std=c++0x"
+add_files firmware/BDT.cpp -cflags "-std=c++0x"
 add_files firmware/myproject.cpp -cflags "-std=c++0x"
 add_files -tb myproject_test.cpp -cflags "-I firmware/ -std=c++0x"
 add_files -tb firmware/weights

--- a/conifer/backends/xilinxhls/hls-template/firmware/BDT_rolled.cpp
+++ b/conifer/backends/xilinxhls/hls-template/firmware/BDT_rolled.cpp
@@ -1,0 +1,13 @@
+#include "BDT.h"
+#include "parameters.h"
+
+template<>
+void BDT::BDT<n_trees, max_depth, n_classes, input_arr_t, score_t, threshold_t, unroll>::tree_scores(input_arr_t x, score_t scores[n_trees][fn_classes(n_classes)]) const {
+  Trees:
+  for(int i = 0; i < n_trees; i++){
+    Classes:
+    for(int j = 0; j < fn_classes(n_classes); j++){
+      scores[i][j] = trees[i][j].decision_function(x);
+    }
+  }
+}

--- a/conifer/backends/xilinxhls/hls-template/firmware/BDT_unrolled.cpp
+++ b/conifer/backends/xilinxhls/hls-template/firmware/BDT_unrolled.cpp
@@ -1,0 +1,8 @@
+#include "BDT.h"
+#include "parameters.h"
+
+template<>
+void BDT::BDT<n_trees, n_classes, input_arr_t, score_t, threshold_t>::tree_scores(input_arr_t x, score_t scores[n_trees][fn_classes(n_classes)]) const {
+  // conifer insert tree_scores
+}
+

--- a/conifer/backends/xilinxhls/writer.py
+++ b/conifer/backends/xilinxhls/writer.py
@@ -44,16 +44,16 @@ def get_hls():
 
 class XilinxHLSConfig(MultiPrecisionConfig):
     backend = 'xilinxhls'
-    _config_fields = MultiPrecisionConfig._config_fields + ['xilinx_part', 'clock_period', 'pipeline']
+    _config_fields = MultiPrecisionConfig._config_fields + ['xilinx_part', 'clock_period', 'unroll']
     _xhls_alts = {'xilinx_part'  : ['XilinxPart'],
                   'clock_period' : ['ClockPeriod'],
-                  'pipeline'     : ['Pipeline']
+                  'unroll'       : ['Unroll']
                   }
     _alternates = {**MultiPrecisionConfig._alternates, **_xhls_alts}
     _xhls_defaults = {'precision'    : 'ap_fixed<18,8>',
                       'xilinx_part'  : 'xcvu9p-flgb2104-2L-e',
                       'clock_period' : 5,
-                      'pipeline'     : True
+                      'unroll'     : True
                       }
     _defaults = {**MultiPrecisionConfig._defaults, **_xhls_defaults}
     def __init__(self, configDict, validate=True):
@@ -76,46 +76,44 @@ class XilinxHLSModel(ModelBase):
             for tree in trees_class:
                 tree.padTree(self.max_depth)
 
-    @copydocstring(ModelBase.write)
-    def write(self):
-
-        self.save()
+    def write_bdt_h(self):
+        '''
+        Write the BDT.h file depending on configuration options
+        '''
         cfg = self.config
-
         filedir = os.path.dirname(os.path.abspath(__file__))
+        
+        if cfg.unroll:
+            copyfile(f'{filedir}/firmware/BDT_unrolled.h',
+                     f'{cfg.output_dir}/firmware/BDT.h')    
+        else:        
+            copyfile(f'{filedir}/firmware/BDT_rolled.h',
+                     f'{cfg.output_dir}/firmware/BDT.h')
 
-        logger.info(f"Writing project to {cfg.output_dir}")
+        if cfg.unroll:
+            fin = open(f'{filedir}/hls-template/firmware/BDT_unrolled.cpp', 'r')
+            fout = open(f'{cfg.output_dir}/firmware/BDT.cpp', 'w')
+            for line in fin.readlines():
+                if '// conifer insert tree_scores' in line:
+                    newline = ''
+                    for it, trees in enumerate(self.trees):
+                        for ic, tree in enumerate(trees):
+                            newline += f'  scores[{it}][{ic}] = tree_{it}_{ic}.decision_function(x);\n'
+                else:
+                    newline = line
+                fout.write(newline)
+        else:
+            copyfile(f'{filedir}/hls-template/firmware/BDT_rolled.cpp',
+                     f'{cfg.output_dir}/firmware/BDT.cpp')
 
-        os.makedirs('{}/firmware'.format(cfg.output_dir), exist_ok=True)
-        os.makedirs('{}/tb_data'.format(cfg.output_dir), exist_ok=True)
-        copyfile('{}/firmware/BDT.h'.format(filedir),
-                '{}/firmware/BDT.h'.format(cfg.output_dir))
 
-        ###################
-        # myproject.cpp
-        ###################
+    def write_parameters_h(self):
+        '''
+        Write the parameters.h file depending on the configuration
+        '''
 
-        fout = open(
-            '{}/firmware/{}.cpp'.format(cfg.output_dir, cfg.project_name), 'w')
-        fout.write('#include "BDT.h"\n')
-        fout.write('#include "parameters.h"\n')
-        fout.write('#include "{}.h"\n'.format(cfg.project_name))
-
-        fout.write(
-            'void {}(input_arr_t x, score_arr_t score, score_t tree_scores[BDT::fn_classes(n_classes) * n_trees]){{\n'.format(cfg.project_name))
-        fout.write('\t#pragma HLS array_partition variable=x\n')
-        fout.write('\t#pragma HLS array_partition variable=score\n')
-        fout.write('\t#pragma HLS array_partition variable=tree_scores\n')
-        if(cfg.pipeline):
-            fout.write('\t#pragma HLS pipeline\n')
-            fout.write('\t#pragma HLS unroll\n')
-        fout.write('\tbdt.decision_function(x, score, tree_scores);\n}')
-        fout.close()
-
-        ###################
-        # parameters.h
-        ###################
-
+        cfg = self.config
+        
         fout = open('{}/firmware/parameters.h'.format(cfg.output_dir), 'w')
         fout.write('#ifndef BDT_PARAMS_H__\n#define BDT_PARAMS_H__\n\n')
         fout.write('#include  "BDT.h"\n')
@@ -129,7 +127,7 @@ class XilinxHLSModel(ModelBase):
         fout.write('static const int n_classes = {};\n'.format(
             self.n_classes))
         fout.write('static const bool unroll = {};\n'.format(
-            str(cfg.pipeline).lower()))
+            str(cfg.unroll).lower()))
 
         input_precision = cfg.input_precision
         fout.write('typedef {} input_t;\n'.format(input_precision))
@@ -141,6 +139,65 @@ class XilinxHLSModel(ModelBase):
         score_precision = cfg.score_precision
         fout.write('typedef {} score_t;\n'.format(score_precision))
         fout.write('typedef score_t score_arr_t[n_classes];\n')
+
+        if self.config.unroll:
+            self._write_parameters_h_unrolled(fout)
+        else:
+            self._write_parameters_h_array(fout)
+        fout.close()       
+
+    def _write_parameters_h_unrolled(self, fout):
+        '''
+        Write the parameters.h file with manually unrolled trees
+        '''
+        cfg = self.config
+        tree_fields = ['feature', 'threshold', 'value',
+                       'children_left', 'children_right', 'parent']
+
+        # write the BDT instance
+        fout.write(
+            "static const BDT::BDT<n_trees, n_classes, input_arr_t, score_t, threshold_t> bdt = \n")
+        fout.write("{ // The struct\n")
+        newline = "\t" + str(self.norm) + ", // The normalisation\n"
+        fout.write(newline)
+        newline = "\t{"
+        if self.n_classes > 2:
+            for iip, ip in enumerate(self.init_predict):
+                if iip < len(self.init_predict) - 1:
+                    newline += '{},'.format(ip)
+                else:
+                    newline += '{}}}, // The init_predict\n}};'.format(ip)
+        else:
+            newline += str(self.init_predict[0]) + '},\n}; // bdt\n'
+        fout.write(newline)
+
+        # write the trees instances
+        nc = 1 if self.n_classes == 2 else self.n_classes
+        fout.write("// The trees\n")
+        # loop over trees
+        for itree, trees in enumerate(self.trees):
+            # loop over classes
+            for iclass, tree in enumerate(trees):
+                fout.write(f'static const BDT::Tree<{itree*nc+iclass}, {tree.n_nodes()}, {tree.n_leaves()}')
+                fout.write(f', input_arr_t, score_t, threshold_t>')
+                fout.write(f' tree_{itree}_{iclass} = {{\n')
+                # loop over fields
+                for ifield, field in enumerate(tree_fields):
+                    newline = '    {'
+                    newline += ','.join(map(str, getattr(tree, field)))
+                    newline += '}'
+                    if ifield < len(tree_fields) - 1:
+                        newline += ','
+                    newline += '\n'
+                    fout.write(newline)
+                fout.write('};\n')
+            #fout.write(newline)
+        fout.write('#endif')
+
+    def _write_parameters_h_array(self, fout):
+        '''
+        Write the parameters.h file with the array of trees
+        '''
 
         tree_fields = ['feature', 'threshold', 'value',
                     'children_left', 'children_right', 'parent']
@@ -187,8 +244,42 @@ class XilinxHLSModel(ModelBase):
             newline += '\n'
             fout.write(newline)
         fout.write('\t}\n};')
-
         fout.write('\n#endif')
+
+    @copydocstring(ModelBase.write)
+    def write(self):
+
+        self.save()
+        cfg = self.config
+
+        filedir = os.path.dirname(os.path.abspath(__file__))
+
+        logger.info(f"Writing project to {cfg.output_dir}")
+
+        os.makedirs('{}/firmware'.format(cfg.output_dir), exist_ok=True)
+        os.makedirs('{}/tb_data'.format(cfg.output_dir), exist_ok=True)
+
+        self.write_bdt_h()
+        self.write_parameters_h()
+
+        ###################
+        # myproject.cpp
+        ###################
+
+        fout = open(
+            '{}/firmware/{}.cpp'.format(cfg.output_dir, cfg.project_name), 'w')
+        fout.write('#include "BDT.h"\n')
+        fout.write('#include "parameters.h"\n')
+        fout.write('#include "{}.h"\n'.format(cfg.project_name))
+
+        fout.write(
+            'void {}(input_arr_t x, score_arr_t score){{\n'.format(cfg.project_name))
+        fout.write('\t#pragma HLS array_partition variable=x\n')
+        fout.write('\t#pragma HLS array_partition variable=score\n')
+        if(cfg.unroll):
+            fout.write('\t#pragma HLS pipeline\n')
+            fout.write('\t#pragma HLS unroll\n')
+        fout.write('\tbdt.decision_function(x, score);\n}')
         fout.close()
 
         #######################
@@ -361,7 +452,7 @@ class XilinxHLSModel(ModelBase):
         if ap_include is None:
             os.chdir(curr_dir)
             raise Exception("Couldn't find Xilinx ap_ headers. Source the Vivado/Vitis HLS toolchain, or set XILINX_AP_INCLUDE environment variable.")
-        cmd = f"g++ -O3 -shared -std=c++14 -fPIC $(python3 -m pybind11 --includes) {ap_include} bridge.cpp firmware/{cfg.project_name}.cpp -o conifer_bridge_{self._stamp}.so"
+        cmd = f"g++ -O3 -shared -std=c++14 -fPIC $(python3 -m pybind11 --includes) {ap_include} bridge.cpp firmware/BDT.cpp firmware/{cfg.project_name}.cpp -o conifer_bridge_{self._stamp}.so"
         logger.debug(f'Compiling with command {cmd}')
         try:
             ret_val = os.system(cmd)
@@ -423,7 +514,7 @@ def auto_config(granularity='simple'):
               'OutputDir': 'my-conifer-prj',
               'XilinxPart': 'xcvu9p-flgb2104-2L-e',
               'ClockPeriod': '5',
-              'Pipeline' : True}
+              'Unroll' : True}
     if granularity == 'full':
         config['InputPrecision'] = 'ap_fixed<18,8>'
         config['ThresholdPrecision'] = 'ap_fixed<18,8>'

--- a/conifer/model.py
+++ b/conifer/model.py
@@ -19,6 +19,12 @@ class DecisionTreeBase:
       assert val is not None, f"Missing expected key {key} in treeDict"
       setattr(self, key, val)
 
+  def n_nodes(self):
+    return len(self.feature)
+
+  def n_leaves(self):
+    return len([n for n in self.feature if n == -2])
+
 class ConfigBase:
     '''
     Conifer Config representation class


### PR DESCRIPTION
This PR is inspired by #30.

In the main branch, the loop over ensemble trees in the HLS is like this (simplified):
```
for(int i = 0; i < n_trees; i++){
    tree_scores[i] = trees[i].decision_function(x);
}
```
Vivado/Vitis HLS seems to have a hard time unrolling this loop, for an unknown reason. In this PR we manually unroll this loop in the backend writer instead. So for a model with 5 trees this looks like (simplified):
```
  scores[0] = tree_0.decision_function(x);
  scores[1] = tree_1.decision_function(x);
  scores[2] = tree_2.decision_function(x);
  scores[3] = tree_3.decision_function(x);
  scores[4] = tree_4.decision_function(x);
```
Now we also need to create instances of each tree (`tree_0`, `tree_1` etc) instead of an array of them in `parameters.h`, and create one model specific function with the unrolled inference code. 

The impact is:
- reduced resources (including after Vivado logic synthesis)
- equal or slightly increased latency
- much reduced C Synthesis time (6 hours reduced to 12 minutes in the best case)
- increased C Synthesis memory usage

For large models (e.g. in the scan referenced below with 100 trees and depth of 8) master branch may not be able to synthesize the model while this PR can.
The old implementation with a `for` loop in the C++ is still available, with a new configuration parameter `'Unroll'` made available to select between the implementations (defaults to `True`).

For reference, here are some plots from a scan of randomized trees (blue markers are `master` branch, red markers are this PR):

<table>
<tr>
<td><img width="400" alt="Screenshot 2023-03-30 at 15 09 48" src="https://user-images.githubusercontent.com/14807534/228846601-b2c763ac-d63a-4a5d-ae98-6711ae822f55.png"></td>
<td><img width="400" alt="Screenshot 2023-03-30 at 15 11 01" src="https://user-images.githubusercontent.com/14807534/228846607-9c7bb963-d8e7-45ec-bb60-7a57ac63707f.png"></td>
</tr>
<tr>
<td><img width="400" alt="Screenshot 2023-03-30 at 14 58 17" src="https://user-images.githubusercontent.com/14807534/228843840-c2e882ba-7ffb-4ebd-bb4f-7f08af2da265.png"></td>
<td><img width="400" alt="Screenshot 2023-03-30 at 14 58 25" src="https://user-images.githubusercontent.com/14807534/228843871-a365fbad-9810-41b7-9c17-753b1bd92b8d.png"></td>
</tr>
</table>
