### PR TITLE
Fpu license

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Available backends:
 
 See our paper in JINST: "[Fast inference of Boosted Decision Trees in FPGAs for particle physics](https://iopscience.iop.org/article/10.1088/1748-0221/15/05/P05026)".
 
-Conifer originated as a development for [hls4ml](https://fastmachinelearning.org/hls4ml/), and borrows heavily from the code and ideas developed for it.
+Conifer originated as a development for [hls4ml](https://fastmachinelearning.org/hls4ml/), and is developed under the [Fast Machine Learning Lab](https://fastmachinelearning.org/).
 
 # Usage
 
@@ -102,3 +102,6 @@ print(fpu.get_info())
 
 
 </details>
+
+# License
+Apart from the source code and binaries of the Forest Processing Unit (FPU), `conifer` is licensed under *Apache v2*. The FPU source code and binaries are licensed under the [*CERN-OHL-P v2*](https://cern.ch/cern-ohl) or later.

--- a/conifer/backends/fpu/src/LICENSE
+++ b/conifer/backends/fpu/src/LICENSE
@@ -1,0 +1,199 @@
+CERN Open Hardware Licence Version 2 - Permissive
+
+
+Preamble
+
+CERN has developed this licence to promote collaboration among
+hardware designers and to provide a legal tool which supports the
+freedom to use, study, modify, share and distribute hardware designs
+and products based on those designs. Version 2 of the CERN Open
+Hardware Licence comes in three variants: this licence, CERN-OHL-P
+(permissive); and two reciprocal licences: CERN-OHL-W (weakly
+reciprocal) and CERN-OHL-S (strongly reciprocal).
+
+The CERN-OHL-P is copyright CERN 2020. Anyone is welcome to use it, in
+unmodified form only.
+
+Use of this Licence does not imply any endorsement by CERN of any
+Licensor or their designs nor does it imply any involvement by CERN in
+their development.
+
+
+1 Definitions
+
+  1.1 'Licence' means this CERN-OHL-P.
+
+  1.2 'Source' means information such as design materials or digital
+      code which can be applied to Make or test a Product or to
+      prepare a Product for use, Conveyance or sale, regardless of its
+      medium or how it is expressed. It may include Notices.
+
+  1.3 'Covered Source' means Source that is explicitly made available
+      under this Licence.
+
+  1.4 'Product' means any device, component, work or physical object,
+      whether in finished or intermediate form, arising from the use,
+      application or processing of Covered Source.
+
+  1.5 'Make' means to create or configure something, whether by
+      manufacture, assembly, compiling, loading or applying Covered
+      Source or another Product or otherwise.
+
+  1.6 'Notice' means copyright, acknowledgement and trademark notices,
+      references to the location of any Notices, modification notices
+      (subsection 3.3(b)) and all notices that refer to this Licence
+      and to the disclaimer of warranties that are included in the
+      Covered Source.
+
+  1.7 'Licensee' or 'You' means any person exercising rights under
+      this Licence.
+
+  1.8 'Licensor' means a person who creates Source or modifies Covered
+      Source and subsequently Conveys the resulting Covered Source
+      under the terms and conditions of this Licence. A person may be
+      a Licensee and a Licensor at the same time.
+
+  1.9 'Convey' means to communicate to the public or distribute.
+
+
+2 Applicability
+
+  2.1 This Licence governs the use, copying, modification, Conveying
+      of Covered Source and Products, and the Making of Products. By
+      exercising any right granted under this Licence, You irrevocably
+      accept these terms and conditions.
+
+  2.2 This Licence is granted by the Licensor directly to You, and
+      shall apply worldwide and without limitation in time.
+
+  2.3 You shall not attempt to restrict by contract or otherwise the
+      rights granted under this Licence to other Licensees.
+
+  2.4 This Licence is not intended to restrict fair use, fair dealing,
+      or any other similar right.
+
+
+3 Copying, Modifying and Conveying Covered Source
+
+  3.1 You may copy and Convey verbatim copies of Covered Source, in
+      any medium, provided You retain all Notices.
+
+  3.2 You may modify Covered Source, other than Notices.
+
+      You may only delete Notices if they are no longer applicable to
+      the corresponding Covered Source as modified by You and You may
+      add additional Notices applicable to Your modifications.
+
+  3.3 You may Convey modified Covered Source (with the effect that You
+      shall also become a Licensor) provided that You:
+
+       a) retain Notices as required in subsection 3.2; and
+
+       b) add a Notice to the modified Covered Source stating that You
+          have modified it, with the date and brief description of how
+          You have modified it.
+
+  3.4 You may Convey Covered Source or modified Covered Source under
+      licence terms which differ from the terms of this Licence
+      provided that You:
+
+       a) comply at all times with subsection 3.3; and
+
+       b) provide a copy of this Licence to anyone to whom You
+          Convey Covered Source or modified Covered Source.
+
+
+4 Making and Conveying Products
+
+You may Make Products, and/or Convey them, provided that You ensure
+that the recipient of the Product has access to any Notices applicable
+to the Product.
+
+
+5 DISCLAIMER AND LIABILITY
+
+  5.1 DISCLAIMER OF WARRANTY -- The Covered Source and any Products
+      are provided 'as is' and any express or implied warranties,
+      including, but not limited to, implied warranties of
+      merchantability, of satisfactory quality, non-infringement of
+      third party rights, and fitness for a particular purpose or use
+      are disclaimed in respect of any Source or Product to the
+      maximum extent permitted by law. The Licensor makes no
+      representation that any Source or Product does not or will not
+      infringe any patent, copyright, trade secret or other
+      proprietary right. The entire risk as to the use, quality, and
+      performance of any Source or Product shall be with You and not
+      the Licensor. This disclaimer of warranty is an essential part
+      of this Licence and a condition for the grant of any rights
+      granted under this Licence.
+
+  5.2 EXCLUSION AND LIMITATION OF LIABILITY -- The Licensor shall, to
+      the maximum extent permitted by law, have no liability for
+      direct, indirect, special, incidental, consequential, exemplary,
+      punitive or other damages of any character including, without
+      limitation, procurement of substitute goods or services, loss of
+      use, data or profits, or business interruption, however caused
+      and on any theory of contract, warranty, tort (including
+      negligence), product liability or otherwise, arising in any way
+      in relation to the Covered Source, modified Covered Source
+      and/or the Making or Conveyance of a Product, even if advised of
+      the possibility of such damages, and You shall hold the
+      Licensor(s) free and harmless from any liability, costs,
+      damages, fees and expenses, including claims by third parties,
+      in relation to such use.
+
+
+6 Patents
+
+  6.1 Subject to the terms and conditions of this Licence, each
+      Licensor hereby grants to You a perpetual, worldwide,
+      non-exclusive, no-charge, royalty-free, irrevocable (except as
+      stated in this section 6, or where terminated by the Licensor
+      for cause) patent licence to Make, have Made, use, offer to
+      sell, sell, import, and otherwise transfer the Covered Source
+      and Products, where such licence applies only to those patent
+      claims licensable by such Licensor that are necessarily
+      infringed by exercising rights under the Covered Source as
+      Conveyed by that Licensor.
+
+  6.2 If You institute patent litigation against any entity (including
+      a cross-claim or counterclaim in a lawsuit) alleging that the
+      Covered Source or a Product constitutes direct or contributory
+      patent infringement, or You seek any declaration that a patent
+      licensed to You under this Licence is invalid or unenforceable
+      then any rights granted to You under this Licence shall
+      terminate as of the date such process is initiated.
+
+
+7 General
+
+  7.1 If any provisions of this Licence are or subsequently become
+      invalid or unenforceable for any reason, the remaining
+      provisions shall remain effective.
+
+  7.2 You shall not use any of the name (including acronyms and
+      abbreviations), image, or logo by which the Licensor or CERN is
+      known, except where needed to comply with section 3, or where
+      the use is otherwise allowed by law. Any such permitted use
+      shall be factual and shall not be made so as to suggest any kind
+      of endorsement or implication of involvement by the Licensor or
+      its personnel.
+
+  7.3 CERN may publish updated versions and variants of this Licence
+      which it considers to be in the spirit of this version, but may
+      differ in detail to address new problems or concerns. New
+      versions will be published with a unique version number and a
+      variant identifier specifying the variant. If the Licensor has
+      specified that a given variant applies to the Covered Source
+      without specifying a version, You may treat that Covered Source
+      as being released under any version of the CERN-OHL with that
+      variant. If no variant is specified, the Covered Source shall be
+      treated as being released under CERN-OHL-S. The Licensor may
+      also specify that the Covered Source is subject to a specific
+      version of the CERN-OHL or any later version in which case You
+      may apply this or any later version of CERN-OHL with the same
+      variant identifier published by CERN.
+
+  7.4 This Licence shall not be enforceable except by a Licensor
+      acting as such, and third party beneficiary rights are
+      specifically excluded.

--- a/conifer/backends/fpu/src/README.md
+++ b/conifer/backends/fpu/src/README.md
@@ -1,0 +1,18 @@
+## License
+
+All files in this directory and its subdirectories are licensed under [*CERN-OHL-P v2*](https://cern.ch/cern-ohl) or later.
+
+```
+Copyright CERN 2023.
+
+This source describes Open Hardware and is licensed under the CERN-OHL-P v2
+You may redistribute and modify this documentation and make products
+using it under the terms of the CERN-OHL-P v2 (https:/cern.ch/cern-ohl).
+
+This code is distributed WITHOUT ANY EXPRESS OR IMPLIED
+WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-P v2
+for applicable conditions
+
+Source location: https://github.com/thesps/conifer
+```

--- a/conifer/backends/fpu/src/build_bit.tcl
+++ b/conifer/backends/fpu/src/build_bit.tcl
@@ -1,3 +1,16 @@
+# Copyright CERN 2023.
+#
+# This source describes Open Hardware and is licensed under the CERN-OHL-P v2
+# You may redistribute and modify this documentation and make products
+# using it under the terms of the CERN-OHL-P v2 (https:/cern.ch/cern-ohl).
+#
+# This code is distributed WITHOUT ANY EXPRESS OR IMPLIED
+# WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+# AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-P v2
+# for applicable conditions
+#
+# Source location: https://github.com/thesps/conifer
+
 set tcldir [file dirname [info script]]
 source [file join $tcldir parameters.tcl]
 

--- a/conifer/backends/fpu/src/build_hls.tcl
+++ b/conifer/backends/fpu/src/build_hls.tcl
@@ -1,3 +1,16 @@
+# Copyright CERN 2023.
+#
+# This source describes Open Hardware and is licensed under the CERN-OHL-P v2
+# You may redistribute and modify this documentation and make products
+# using it under the terms of the CERN-OHL-P v2 (https:/cern.ch/cern-ohl).
+#
+# This code is distributed WITHOUT ANY EXPRESS OR IMPLIED
+# WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+# AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-P v2
+# for applicable conditions
+#
+# Source location: https://github.com/thesps/conifer
+
 set tcldir [file dirname [info script]]
 source [file join $tcldir parameters.tcl]
 

--- a/conifer/backends/fpu/src/changes.txt
+++ b/conifer/backends/fpu/src/changes.txt
@@ -1,0 +1,7 @@
+Summary of changes to FPU hardware design
+Date format: dd/mm/yyyy
+
+20/12/2022 - First implementation FPU
+17/01/2023 - Added support for batched inference for Alveo design
+25/01/2023 - Added support for floating-point interface with dynamic scaling
+06/02/2023 - Added support for batched inference for Zynq design

--- a/conifer/backends/fpu/src/fpu.cpp
+++ b/conifer/backends/fpu/src/fpu.cpp
@@ -1,4 +1,19 @@
 /*
+Copyright CERN 2023.
+
+This source describes Open Hardware and is licensed under the CERN-OHL-P v2
+You may redistribute and modify this documentation and make products
+using it under the terms of the CERN-OHL-P v2 (https:/cern.ch/cern-ohl).
+
+This code is distributed WITHOUT ANY EXPRESS OR IMPLIED
+WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-P v2
+for applicable conditions
+
+Source location: https://github.com/thesps/conifer
+*/
+
+/*
 * Forest Processing Unit top level
 */
 

--- a/conifer/backends/fpu/src/fpu.h
+++ b/conifer/backends/fpu/src/fpu.h
@@ -1,3 +1,18 @@
+/*
+Copyright CERN 2023.
+
+This source describes Open Hardware and is licensed under the CERN-OHL-P v2
+You may redistribute and modify this documentation and make products
+using it under the terms of the CERN-OHL-P v2 (https:/cern.ch/cern-ohl).
+
+This code is distributed WITHOUT ANY EXPRESS OR IMPLIED
+WARRANTY, INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY
+AND FITNESS FOR A PARTICULAR PURPOSE. Please see the CERN-OHL-P v2
+for applicable conditions
+
+Source location: https://github.com/thesps/conifer
+*/
+
 #ifndef CONIFER_FPU_H__
 #define CONIFER_FPU_H__
 

--- a/examples/build_fpu_alveo.py
+++ b/examples/build_fpu_alveo.py
@@ -25,3 +25,4 @@ cfg['output_dir'] = 'fpu-0A-u200_100TE_512N_DS'
 builder = AlveoFPUBuilder(cfg)
 
 builder.build(csynth=True, bitfile=True)
+builder.package()

--- a/examples/build_fpu_pynq.py
+++ b/examples/build_fpu_pynq.py
@@ -24,3 +24,4 @@ cfg['output_dir'] = 'fpu-0A-pynq-z2_100TE_512N_DS'
 builder = ZynqFPUBuilder(cfg)
 
 builder.build()
+builder.package()


### PR DESCRIPTION
Apply the [CERN Open Hardware License](https://cern.ch/cern-ohl) to the FPU source code and artefacts.
Plus some modifications to the FPU artefact packaging motivated by including the license in the archive.