### PR TITLE
xgboost updates

### DIFF
--- a/conifer/backends/cpp/template/bridge.cpp
+++ b/conifer/backends/cpp/template/bridge.cpp
@@ -7,7 +7,7 @@
 
 namespace py = pybind11;
 PYBIND11_MODULE(conifer_bridge, m){
-  py::class_<conifer::BDT<T,U,false>>(m, "BDT")
+  py::class_<conifer::BDT<T,U,false>>(m, "BDT", py::module_local())
       .def(py::init<const std::string &>())
       .def("decision_function", &conifer::BDT<T,U>::_decision_function_double);
 }

--- a/conifer/backends/cpp/writer.py
+++ b/conifer/backends/cpp/writer.py
@@ -57,7 +57,7 @@ class CPPModel(ModelBase):
         newline =  f"typedef {cfg.threshold_precision} T;\n"
         newline += f"typedef {cfg.score_precision} U;\n"
       elif 'PYBIND11_MODULE' in line:
-        newline = f'PYBIND11_MODULE(conifer_bridge_{self._stamp}, m){{\n'
+        newline = line.replace('conifer_bridge', f'conifer_bridge_{self._stamp}')
       elif '// conifer insert include' in line:
         newline = '#include "ap_fixed.h"' if cfg.any_ap_types() else ''
       fout.write(newline)

--- a/conifer/converters/__init__.py
+++ b/conifer/converters/__init__.py
@@ -1,24 +1,16 @@
-from conifer.converters import sklearn
-from conifer.converters import tmva
-from conifer.converters import xgboost
-from conifer.converters import onnx
-from conifer.model import make_model
-
-try:
-    from conifer.converters import tf_df
-except ImportError:
-    tf_df = None
-    print("Warning: The python package tensorflow_decision_forests is not available. Conversions "
-          "from TensorFlow Decision Forests models is not possible.")
-
 import logging
 logger = logging.getLogger(__name__)
 
-_converter_map = {'sklearn' : sklearn,
-                  'tmva'    : tmva,
-                  'xgboost' : xgboost,
-                  'onnx'    : onnx,
-                  'tf_df':  tf_df}
+_converter_map = {}
+import importlib
+for module in ['sklearn', 'tmva', 'xgboost', 'onnx', 'tf_df']:
+  try:
+    the_module = importlib.import_module(f'conifer.converters.{module}')
+    _converter_map[module] = the_module
+  except ImportError:
+    logger.warn(f'Could not import conifer {module} converter')
+
+from conifer.model import make_model
 
 def get_converter(converter):
   '''Get converter object from string'''

--- a/conifer/converters/xgboost.py
+++ b/conifer/converters/xgboost.py
@@ -1,30 +1,39 @@
 import numpy as np
 import json
+import xgboost as xgb
+from typing import Union
 
-def convert(bdt):
-    meta = json.loads(bdt.save_config())
-    max_depth = int(meta['learner']['gradient_booster']['updater']['grow_colmaker']['train_param']['max_depth'])
-    n_classes = int(meta['learner']['learner_model_param']['num_class'])
+def convert(bdt : Union[xgb.core.Booster, xgb.XGBClassifier]):
+    assert isinstance(bdt, (xgb.core.Booster, xgb.XGBClassifier))
+    if isinstance(bdt, xgb.core.Booster):
+      bst = bdt
+    elif isinstance(bdt, (xgb.XGBClassifier)):
+      bst = bdt.get_booster()
+    meta = json.loads(bst.save_config())
+    updater = meta.get('learner').get('gradient_booster').get('gbtree_train_param').get('updater').split(',')[0]
+    max_depth = int(meta.get('learner').get('gradient_booster').get('updater').get(updater).get('train_param').get('max_depth'))
+    n_classes = int(meta.get('learner').get('learner_model_param').get('num_class'))
+    n_trees = int(meta.get('learner').get('gradient_booster').get('gbtree_model_param').get('num_trees'))
     fn_classes = 1 if n_classes == 0 else n_classes # the number of learners
     n_classes = 2 if n_classes == 0 else n_classes # the actual number of classes
     n_features = int(meta['learner']['learner_model_param']['num_feature'])
     ensembleDict = {'max_depth' : max_depth,
-                    'n_trees' : int(len(bdt.get_dump()) / fn_classes),
+                    'n_trees' : n_trees,
                     'n_classes' : n_classes,
                     'n_features' : n_features,
                     'trees' : [],
-                    'init_predict' : [0] * n_classes,
+                    'init_predict' : [0] * n_classes, # meta.get('learner').get('learner_model_param').get('base_score')
                     'norm' : 1}
     
     feature_names = {}
-    if bdt.feature_names is None:
+    if bst.feature_names is None:
       for i in range(n_features):
         feature_names[f'f{i}'] = i
     else:
-      for i, feature_name in enumerate(bdt.feature_names):
+      for i, feature_name in enumerate(bst.feature_names):
         feature_names[feature_name] = i
 
-    trees = bdt.get_dump()
+    trees = bst.get_dump()
     for i in range(ensembleDict['n_trees']):
         treesl = []
         for j in range(fn_classes):

--- a/tests/test_xgb_converter.py
+++ b/tests/test_xgb_converter.py
@@ -1,0 +1,86 @@
+from sklearn.datasets import make_hastie_10_2
+import xgboost as xgb
+import conifer
+import datetime
+from scipy.special import expit, logit
+import numpy as np
+import pytest
+import logging
+import sys
+
+#logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
+# Make a random dataset from sklearn 'hastie'
+X, y = make_hastie_10_2(random_state=0)
+y[y == -1] = 0
+X_train, X_test = X[:2000], X[2000:]
+y_train, y_test = y[:2000], y[2000:]
+
+dtrain = xgb.DMatrix(X_train, label=y_train)
+dtest = xgb.DMatrix(X_test, label=y_test)
+
+def get_dmatrix():
+  return dtest
+
+def get_np():
+  return X_test
+
+def model_0():
+  # Train a BDT
+  param = {'max_depth': 3, 'eta': 1, 'objective': 'binary:logistic'}
+  num_round = 20  # num_round is equivalent to number of trees
+  bst = xgb.train(param, dtrain, num_round)
+  return bst
+
+def model_1():
+  # Train a BDT
+  param = {'max_depth': 3, 'eta': 1, 'objective': 'binary:logistic', 'updater':'grow_histmaker'}
+  num_round = 20  # num_round is equivalent to number of trees
+  bst = xgb.train(param, dtrain, num_round)
+  return bst
+
+def model_2():
+  bdt = xgb.XGBClassifier(n_estimators=10, max_depth=3)
+  bdt.fit(X_train, y_train)  
+  return bdt
+
+def model_3():
+  bdt = xgb.XGBRegressor(n_estimators=10, max_depth=3)
+  bdt.fit(X_train, y_train)  
+  return bdt
+
+def predict_logit(model, x):
+  return logit(model.predict(x))
+
+def predict_proba(model, x):
+  return logit(model.predict_proba(x)[:,1])
+
+def predict(model, x):
+  return logit(model.predict(x))
+
+@pytest.mark.parametrize('params', [(0, model_0, get_dmatrix, get_np, 'predict', expit), 
+                                    (1, model_1, get_dmatrix, get_np, 'predict', expit),
+                                    (2, model_2, get_np, get_np, 'predict_proba', expit),
+                                    #(3, model_3, get_np, get_np, 'predict', lambda x: x), # not yet possible
+                                    ])
+def test_xgb(params):
+  test_idx = params[0]
+  get_model_function = params[1]
+  get_data_function_xgb = params[2]
+  get_data_function_cnf = params[3]
+  predictor = params[4]
+  transform = params[5]
+  model = get_model_function()
+  x_xgb = get_data_function_xgb()
+  x_cnf = get_data_function_cnf()
+  cfg = conifer.backends.cpp.auto_config()
+  cfg['Precision'] = 'float'
+  # Set the output directory to something unique
+  cfg['OutputDir'] = f'prj_xgb_converter_{test_idx}_{int(datetime.datetime.now().timestamp())}'
+  cnf_model = conifer.converters.convert_from_xgboost(model, cfg)
+  cnf_model.compile()
+  y_cnf = np.squeeze(transform(cnf_model.decision_function(x_cnf)))
+  y_xgb = getattr(model, predictor)(x_xgb)
+  if len(y_xgb.shape) == 2:
+    y_xgb = y_xgb[:,-1]
+  np.testing.assert_array_almost_equal(y_cnf, y_xgb)

--- a/tests/test_xgb_converter.py
+++ b/tests/test_xgb_converter.py
@@ -1,8 +1,8 @@
-from sklearn.datasets import make_hastie_10_2
+from sklearn.datasets import make_hastie_10_2, load_diabetes, load_iris
 import xgboost as xgb
 import conifer
 import datetime
-from scipy.special import expit, logit
+from scipy.special import expit, logit, softmax
 import numpy as np
 import pytest
 import logging
@@ -11,76 +11,79 @@ import sys
 #logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 # Make a random dataset from sklearn 'hastie'
-X, y = make_hastie_10_2(random_state=0)
-y[y == -1] = 0
-X_train, X_test = X[:2000], X[2000:]
-y_train, y_test = y[:2000], y[2000:]
+# binary classification
+def hastie():
+  X, y = make_hastie_10_2(random_state=0)
+  y[y == -1] = 0
+  return X, y, xgb.DMatrix(X, label=y)
 
-dtrain = xgb.DMatrix(X_train, label=y_train)
-dtest = xgb.DMatrix(X_test, label=y_test)
+# multiclass classification
+def iris():
+  X, y = load_iris(return_X_y=True)
+  return X, y, xgb.DMatrix(X, label=y)
 
-def get_dmatrix():
-  return dtest
+# regression
+def diabetes():
+  X, y = load_diabetes(return_X_y=True)
+  return X, y, xgb.DMatrix(X, label=y)
 
-def get_np():
-  return X_test
-
-def model_0():
+def model_0(d, kwarg_params={}):
   # Train a BDT
   param = {'max_depth': 3, 'eta': 1, 'objective': 'binary:logistic'}
+  param.update(kwarg_params)
   num_round = 20  # num_round is equivalent to number of trees
-  bst = xgb.train(param, dtrain, num_round)
+  bst = xgb.train(param, d, num_round)
   return bst
 
-def model_1():
+def model_1(d, kwarg_params={}):
   # Train a BDT
   param = {'max_depth': 3, 'eta': 1, 'objective': 'binary:logistic', 'updater':'grow_histmaker'}
+  param.update(kwarg_params)
   num_round = 20  # num_round is equivalent to number of trees
-  bst = xgb.train(param, dtrain, num_round)
+  bst = xgb.train(param, d, num_round)
   return bst
 
-def model_2():
-  bdt = xgb.XGBClassifier(n_estimators=10, max_depth=3)
-  bdt.fit(X_train, y_train)  
+def model_2(X, y, kwarg_params={}):
+  bdt = xgb.XGBClassifier(n_estimators=10, max_depth=3, **kwarg_params)
+  bdt.fit(X, y)  
   return bdt
 
-def model_3():
-  bdt = xgb.XGBRegressor(n_estimators=10, max_depth=3)
-  bdt.fit(X_train, y_train)  
+def model_3(X, y, kwarg_params={}):
+  bdt = xgb.XGBRegressor(n_estimators=10, max_depth=3, **kwarg_params)
+  bdt.fit(X, y)  
   return bdt
 
-def predict_logit(model, x):
-  return logit(model.predict(x))
-
-def predict_proba(model, x):
-  return logit(model.predict_proba(x)[:,1])
-
-def predict(model, x):
-  return logit(model.predict(x))
-
-@pytest.mark.parametrize('params', [(0, model_0, get_dmatrix, get_np, 'predict', expit), 
-                                    (1, model_1, get_dmatrix, get_np, 'predict', expit),
-                                    (2, model_2, get_np, get_np, 'predict_proba', expit),
-                                    #(3, model_3, get_np, get_np, 'predict', lambda x: x), # not yet possible
+# parameter format: (test index, model function, data function, data fmt ['np', 'xgb'], predictor function, prediction transform)
+@pytest.mark.parametrize('params', [(0, model_0, {}, hastie, 'xgb', 'predict', expit, {}), 
+                                    (1, model_1, {}, hastie, 'xgb', 'predict', expit, {}),
+                                    (2, model_2, {}, hastie, 'np', 'predict_proba', expit, {}),
+                                    (3, model_2, {}, iris, 'np', 'predict_proba', softmax, {'axis':1}),
+                                    (4, model_0, {'objective': 'multi:softprob', 'num_class': 3}, iris, 'xgb', 'predict', softmax, {'axis':1}),
+                                    (5, model_3, {}, diabetes, 'np', 'predict', lambda x: x, {}), # not yet possible
                                     ])
 def test_xgb(params):
   test_idx = params[0]
   get_model_function = params[1]
-  get_data_function_xgb = params[2]
-  get_data_function_cnf = params[3]
-  predictor = params[4]
-  transform = params[5]
-  model = get_model_function()
-  x_xgb = get_data_function_xgb()
-  x_cnf = get_data_function_cnf()
+  get_model_kwargs = params[2]
+  get_data_function = params[3]
+  data_fmt = params[4]
+  predictor = params[5]
+  transform = params[6]
+  transform_kwargs = params[7]
+  X, y, d = get_data_function()
+  if data_fmt == 'xgb':
+    model = get_model_function(d, get_model_kwargs)
+  else:
+    model = get_model_function(X, y, get_model_kwargs)
   cfg = conifer.backends.cpp.auto_config()
-  cfg['Precision'] = 'float'
+  cfg['Precision'] = 'double'
   # Set the output directory to something unique
   cfg['OutputDir'] = f'prj_xgb_converter_{test_idx}_{int(datetime.datetime.now().timestamp())}'
   cnf_model = conifer.converters.convert_from_xgboost(model, cfg)
   cnf_model.compile()
-  y_cnf = np.squeeze(transform(cnf_model.decision_function(x_cnf)))
-  y_xgb = getattr(model, predictor)(x_xgb)
-  if len(y_xgb.shape) == 2:
+  y_cnf = np.squeeze(transform(cnf_model.decision_function(X), **transform_kwargs))
+  X_xgb = X if data_fmt == 'np' else d
+  y_xgb = getattr(model, predictor)(X_xgb)
+  if len(y_xgb.shape) == 2 and y_xgb.shape[1] == 2:
     y_xgb = y_xgb[:,-1]
   np.testing.assert_array_almost_equal(y_cnf, y_xgb)


### PR DESCRIPTION
Initiated by #46 

- fix the xgboost converter when the `updater` is not the default
- fix xgboost multiclass conversion
- accept `XGBClassifier` and `XGBRegressor` objects for conversion as well as `Booster` as before
- simplify `treeToDict` for xgboost converter by using `trees_to_dataframe` method of `Booster`
- add xgboost converter test
- generally allow converters to import non-required modules and `try` to import them in the `__init__.py`

Not relate to xgboost:
- fix to C++ backend for importing multiple pybind11 bridge modules (e.g. different models)