### PR TITLE
Python backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Available backends:
 - VHDL - a direct-to-VHDL implementation, deeply pipelined for high clock frequencies
 - FPU - Forest Processing Unit reusable IP core for flexible BDT inference
 - C++ - intended for bit-accurate emulation on CPU with a single include header file
+- Python - intended for validation of model conversion and to allow inspection of a model without a configuration
 
 See our paper in JINST: "[Fast inference of Boosted Decision Trees in FPGAs for particle physics](https://iopscience.iop.org/article/10.1088/1748-0221/15/05/P05026)".
 
@@ -47,9 +48,8 @@ cfg = conifer.backends.xilinxhls.auto_config()
 # Change the bit precision (print the config to see everything modifiable)
 cfg['Precision'] = 'ap_fixed<12,4>' 
 
-# Create the conifer model
-model = conifer.model(clf, conifer.converters.sklearn,
-                      conifer.backends.xilinxhls, cfg)
+# Convert the sklearn model to a conifer model
+model = conifer.converters.convert_from_sklearn(clf, cfg)
 # Write the HLS project and compile the C++-Python bridge                      
 model.compile()
 

--- a/conifer/backends/__init__.py
+++ b/conifer/backends/__init__.py
@@ -19,12 +19,23 @@ from conifer.backends import vhdl
 from conifer.backends import cpp
 from conifer.backends import fpu
 
+class python_backend:
+  '''
+  Simple backend to make a ModelBase object
+  '''
+  def make_model(ensembleDict, config):
+    from conifer.model import ModelBase
+    return ModelBase(ensembleDict, config)
+
 _backend_map = {'xilinxhls' : xilinxhls,
                 'vivadohls' : vivadohls,
                 'vitishls'  : vitishls,
                 'vhdl'      : vhdl,
                 'cpp'       : cpp,
-                'fpu'       : fpu,}
+                'fpu'       : fpu,
+                'python'    : python_backend,
+                'py'        : python_backend,
+                }
 
 def get_backend(backend):
   '''Get backend object from string'''

--- a/conifer/converters/__init__.py
+++ b/conifer/converters/__init__.py
@@ -22,27 +22,27 @@ def get_converter(converter):
 def get_available_converters():
   return [k for k in _converter_map.keys()]
 
-def convert_from_sklearn(model, config):
+def convert_from_sklearn(model, config=None):
   '''Convert a BDT from a scikit-learn model and configuration'''
   ensembleDict = sklearn.convert(model)
   return make_model(ensembleDict, config)
 
-def convert_from_tmva(model, config):
+def convert_from_tmva(model, config=None):
   '''Convert a BDT from a TMVA model and configuration'''
   ensembleDict = tmva.convert(model)
   return make_model(ensembleDict, config)
 
-def convert_from_xgboost(model, config):
+def convert_from_xgboost(model, config=None):
   '''Convert a BDT from an xgboost model and configuration'''
   ensembleDict = xgboost.convert(model)
   return make_model(ensembleDict, config)
 
-def convert_from_onnx(model, config):
+def convert_from_onnx(model, config=None):
   '''Convert a BDT from an ONNX model and configuration'''
   ensembleDict = onnx.convert(model)
   return make_model(ensembleDict, config)
 
-def convert_from_tf_df(model, config):
+def convert_from_tf_df(model, config=None):
   '''Convert a BDT from an TF-DF model and configuration'''
   ensembleDict = tf_df.convert(model)
   return make_model(ensembleDict, config)

--- a/conifer/model.py
+++ b/conifer/model.py
@@ -89,6 +89,21 @@ class DecisionTreeBase:
 
     return graph
 
+  def apply(self, X):
+    assert len(X.shape) == 2, 'Expected 2D input'
+    y = np.zeros(X.shape[0], dtype='int')
+    for i, x in enumerate(X):
+      n = 0
+      while self.feature[n] != -2:
+        comp = x[self.feature[n]] <= self.threshold[n]
+        n = self.children_left[n] if comp else self.children_right[n]
+      y[i] = n
+    return y
+
+  def decision_function(self, X):
+    assert len(X.shape) == 2, 'Expected 2D input'
+    yi = self.apply(X)
+    return np.array(self.value)[yi]
 
 class ConfigBase:
     '''
@@ -146,7 +161,7 @@ class ModelBase:
 
     _ensemble_fields = ['n_classes', 'n_features', 'n_trees', 'max_depth', 'init_predict', 'norm']
 
-    def __init__(self, ensembleDict, configDict, metadata=None):
+    def __init__(self, ensembleDict, configDict=None, metadata=None):
         for key in ModelBase._ensemble_fields:
             val = ensembleDict.get(key, None)
             assert val is not None, f'Missing expected key {key} in ensembleDict'
@@ -154,15 +169,20 @@ class ModelBase:
         trees = ensembleDict.get('trees', None)
         assert trees is not None, f'Missing expected key {key} in ensembleDict'
         self.trees = [[DecisionTreeBase(treeDict) for treeDict in trees_class] for trees_class in trees]
-        self.config = ConfigBase(configDict)
 
-        subset_keys = ['max_depth', 'n_trees', 'n_features', 'n_classes']
-        subset_dict = {key: getattr(self, key) for key in subset_keys}
-        logger.debug(f"Converted BDT with parameters {json.dumps(subset_dict)}")
         def _make_stamp():
             import datetime
             return int(datetime.datetime.now().timestamp())
         self._stamp = _make_stamp()
+
+        if configDict is not None:
+            self.config = ConfigBase(configDict)
+        else:
+            self.config = ConfigBase({'output_dir' : '.', 'project_name' : f'conifer_prj_{self._stamp}', 'backend' : 'python'})
+
+        subset_keys = ['max_depth', 'n_trees', 'n_features', 'n_classes']
+        subset_dict = {key: getattr(self, key) for key in subset_keys}
+        logger.debug(f"Converted BDT with parameters {json.dumps(subset_dict)}")
         if metadata is None:
             self._metadata = [ModelMetaData()]
         else:
@@ -194,12 +214,16 @@ class ModelBase:
         js = json.dumps(dictionary, indent=1)
 
         cfg = self.config
-        if filename is None:
+        if filename is None and cfg is not None:
             filename = f"{cfg.output_dir}/{cfg.project_name}.json"
             directory = cfg.output_dir
+        elif filename is not None:
+            directory = os.path.dirname(filename)
+            directory = directory if directory != '' else './'
         else:
-            directory = filename.split('/')[:-1]
-        os.makedirs(directory, exist_ok=True)
+            logger.error('If model has no configuration, filename must be provided')
+        if not os.path.exists(directory):
+            os.makedirs(directory)
         with open(filename, 'w') as f:
             f.write(js)
 
@@ -261,7 +285,17 @@ class ModelBase:
         score: ndarray of shape (n_samples, n_classes) or (n_samples,)   
 
         '''
-        raise NotImplementedError
+        assert len(X.shape) == 2, 'Expected 2D input'
+        assert X.shape[1] == self.n_features, f'Wrong number of features, expected {self.n_features}, got {X.shape[1]}'
+
+        n_classes = 1 if self.n_classes == 2 else self.n_classes
+        n_samples = X.shape[0]
+        y = np.zeros((self.n_trees, n_classes, n_samples))
+        for it, trees in enumerate(self.trees):
+            for ic, tree_c in enumerate(trees):
+                y[it, ic] = tree_c.decision_function(X)
+        y = np.transpose(np.sum(y, axis=0)) + self.init_predict
+        return np.squeeze(y)
 
     def build(self, **kwargs):
         '''
@@ -326,16 +360,19 @@ class ModelMetaData:
         mmd.time = datetime.datetime.fromtimestamp(d.get('time', 0))
         return mmd
 
-def make_model(ensembleDict, config):
+def make_model(ensembleDict, config=None):
     from conifer.backends import get_backend
     backend = None
-    for k in ['backend', 'Backend']:
-        b = config.get(k, None)
-        if b is not None:
-            backend = b
-    if backend is None:
-        logger.warn('Backend not specified in configuration, loading as ModelBase. It will not be possible to write out.')
-        return ModelBase(ensembleDict, config)
+    if config is None:
+        backend = 'python'
+    else:
+        for k in ['backend', 'Backend']:
+            b = config.get(k, None)
+            if b is not None:
+                backend = b
+        if backend is None:
+            logger.warn('Backend not specified in configuration, loading as ModelBase.')
+            return ModelBase(ensembleDict, config)
     backend = get_backend(backend)
     return backend.make_model(ensembleDict, config)
 

--- a/examples/model_saving_loading.py
+++ b/examples/model_saving_loading.py
@@ -1,0 +1,76 @@
+'''
+This example demonstrates saving and loading of conifer models
+Example BDT creation from: https://scikit-learn.org/stable/modules/ensemble.html
+'''
+
+from sklearn.datasets import make_hastie_10_2
+from sklearn.ensemble import GradientBoostingClassifier
+import numpy as np
+import conifer
+import datetime
+import logging
+import sys
+
+logging.basicConfig(stream=sys.stdout, level=logging.WARNING)
+logger = logging.getLogger('conifer')
+logger.setLevel(logging.DEBUG)
+
+##### Part 1 - dataset
+# make a random dataset from sklearn 'hastie'
+X, y = make_hastie_10_2(random_state=0)
+X_train, X_test = X[:2000], X[2000:]
+y_train, y_test = y[:2000], y[2000:]
+
+##### Part 2 - model
+# train a BDT
+clf = GradientBoostingClassifier(n_estimators=20, learning_rate=1.0,
+                                 max_depth=3, random_state=0).fit(X_train, y_train)
+
+# create a timestamp for a unique project directory
+stamp = int(datetime.datetime.now().timestamp())
+
+##### Part 3 - conversion, saving
+# create a conifer config for xilinxhls backend
+cfg_0 = conifer.backends.xilinxhls.auto_config()
+cfg_0['OutputDir'] = f'prj_{stamp}_0'
+
+# convert the model
+model_0 = conifer.converters.convert_from_sklearn(clf, cfg_0)
+
+# compile the model for CPU inference.
+# compile, write, build, and save methods save the model as a JSON file to <output dir>/<project name>.json
+model_0.compile()
+
+y_conifer_0 = model_0.decision_function(X)
+
+##### Part 4 - loading (same config)
+# load the model
+# the configuration is also read from the file so the same backend and settings are applied
+model_1 = conifer.model.load_model(f'prj_{stamp}_0/my_prj.json')
+
+# write it to a different directory
+model_1.output_dir = f'prj_{stamp}_1'
+model_1.compile()
+
+y_conifer_1 = model_1.decision_function(X)
+
+# check the predictions match
+print(f'Original/Loaded model arrays equal: {np.array_equal(y_conifer_0, y_conifer_1)}')
+
+##### Part 5 - loading (new config)
+# a new configuration can be applied when loading the model
+# here we change the backend to 'cpp' and use floating point data types
+cfg_2 = conifer.backends.cpp.auto_config()
+cfg_2['OutputDir'] = f'prj_{stamp}_2'
+model_2 = conifer.model.load_model(f'prj_{stamp}_0/my_prj.json', new_config=cfg_2)
+print(f'Original model backend: {model_0.config.backend}')
+print(f'Loaded model backend:   {model_2.config.backend}')
+
+##### Part 6 - convert then save
+# a model can be converted to conifer without a configuration
+# we can use the native decision_function to check the conversion
+# we can also save the model to JSON for later reloading
+
+model_3 = conifer.converters.convert_from_sklearn(clf)
+print(f'Conversion with no config backend: {model_3.config.backend}')
+model_3.save(f'prj_{stamp}_3.json')

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -65,3 +65,11 @@ def test_backend_equality(test):
   y_a = backend_predict(test.model, name_a, test.X, test.y_shape, test.backend_a, test.config_a)
   y_b = backend_predict(test.model, name_b, test.X, test.y_shape, test.backend_b, test.config_b)
   np.testing.assert_array_equal(y_a, y_b)
+
+def test_py_backend():
+   clf, X, _ = model0
+   model = conifer.converters.convert_from_sklearn(clf)
+   assert model.config.backend == 'python'
+   y_skl = clf.decision_function(X)
+   y_cnf = model.decision_function(X)
+   np.testing.assert_allclose(y_skl, y_cnf, rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
Add a Python backend for native model evaluation without writing out a project. Not intended for high performance, but allows some validation and inspection without targeting another backend.

Allow conversion of a model without a configuration, in which case select Python backend.