### PR TITLE
Miscellaneous Improvements

### DIFF
--- a/conifer/backends/__init__.py
+++ b/conifer/backends/__init__.py
@@ -2,19 +2,6 @@ import sys
 import importlib.util
 
 from conifer.backends import xilinxhls
-
-SPEC_XILINXHLS = importlib.util.find_spec('.xilinxhls', __name__)
-
-vivadohls = importlib.util.module_from_spec(SPEC_XILINXHLS)
-vivadohls._tool = 'vivadohls'
-SPEC_XILINXHLS.loader.exec_module(vivadohls)
-
-vitishls = importlib.util.module_from_spec(SPEC_XILINXHLS)
-vitishls._tool = 'vitishls'
-SPEC_XILINXHLS.loader.exec_module(vitishls)
-
-del SPEC_XILINXHLS
-
 from conifer.backends import vhdl
 from conifer.backends import cpp
 from conifer.backends import fpu
@@ -29,8 +16,6 @@ class python_backend:
     return ModelBase(ensembleDict, config)
 
 _backend_map = {'xilinxhls' : xilinxhls,
-                'vivadohls' : vivadohls,
-                'vitishls'  : vitishls,
                 'vhdl'      : vhdl,
                 'cpp'       : cpp,
                 'fpu'       : fpu,

--- a/conifer/backends/xilinxhls/__init__.py
+++ b/conifer/backends/xilinxhls/__init__.py
@@ -1,20 +1,10 @@
-import sys
-import importlib.util
+import logging
+logger = logging.getLogger(__name__)
 
-SPEC_WRITER = importlib.util.find_spec('.writer', __name__)
-
-writer = importlib.util.module_from_spec(SPEC_WRITER)
-if '_tool' in locals() != None:
-    writer._tool = _tool
-SPEC_WRITER.loader.exec_module(writer)
-
-make_model = writer.make_model
-auto_config = writer.auto_config
-
-del SPEC_WRITER
-
+from conifer.backends.xilinxhls.writer import make_model, auto_config
 try:
     from conifer.backends.xilinxhls import runtime
 except ImportError:
     ZynqDriver = None
+    AlveoDriver = None
     logger.warn('runtime module could not be imported. Interacting with accelerators will not be possible.')

--- a/conifer/backends/xilinxhls/hls-template/vivado_synth.tcl
+++ b/conifer/backends/xilinxhls/hls-template/vivado_synth.tcl
@@ -1,0 +1,3 @@
+add_files {project}/solution1/syn/vhdl
+synth_design -top {top} -part {part}
+report_utilization -file vivado_synth.rpt

--- a/conifer/backends/xilinxhls/writer.py
+++ b/conifer/backends/xilinxhls/writer.py
@@ -115,9 +115,10 @@ class XilinxHLSModel(ModelBase):
         trees = ensembleDict.get('trees', None)
         assert trees is not None, f'Missing expected key trees in ensembleDict'
         self.trees = [[BottomUpDecisionTree(treeDict) for treeDict in trees_class] for trees_class in trees]
-        for trees_class in self.trees:
-            for tree in trees_class:
-                tree.padTree(self.max_depth)
+        if not self.config.unroll:
+            for trees_class in self.trees:
+                for tree in trees_class:
+                    tree.padTree(self.max_depth)
 
     def write_bdt_h(self):
         '''

--- a/conifer/backends/xilinxhls/writer.py
+++ b/conifer/backends/xilinxhls/writer.py
@@ -33,13 +33,10 @@ def get_hls():
 
     tool_exe = None
 
-    if '_tool' in globals():
-        tool_exe = get_tool_exe_in_path(_tool)
-    else:
-        for tool in _TOOLS.keys():
-            tool_exe = get_tool_exe_in_path(tool)
-            if tool_exe != None:
-                break
+    for tool in _TOOLS.keys():
+        tool_exe = get_tool_exe_in_path(tool)
+        if tool_exe != None:
+            break
 
     return tool_exe
 

--- a/conifer/backends/xilinxhls/writer.py
+++ b/conifer/backends/xilinxhls/writer.py
@@ -4,7 +4,7 @@ import warnings
 import numpy as np
 import copy
 from conifer.utils import _ap_include, _gcc_opts, _py_executable, copydocstring
-from conifer.backends.common import BottomUpDecisionTree, MultiPrecisionConfig, read_hls_report
+from conifer.backends.common import BottomUpDecisionTree, MultiPrecisionConfig, read_hls_report, read_vsynth_report
 from conifer.backends.boards import get_board_config, get_builder, BoardConfig, AlveoConfig, ZynqConfig
 from conifer.model import ModelBase, ConfigBase
 import datetime
@@ -466,6 +466,19 @@ class XilinxHLSModel(ModelBase):
             f.write(f'set version {conifer.__version__.major}.{conifer.__version__.minor}\n')
 
         #######################
+        # vivado_synth.tcl
+        #######################
+        f = open(os.path.join(filedir, 'hls-template/vivado_synth.tcl'), 'r')
+        fout = open('{}/vivado_synth.tcl'.format(cfg.output_dir), 'w')
+
+        txt = f.read()
+        txt = txt.format(project=f'{cfg.project_name}_prj', top=cfg.project_name, part=cfg.xilinx_part)
+        fout.write(txt)
+
+        f.close()
+        fout.close()
+
+        #######################
         # bridge.cpp
         #######################
 
@@ -535,7 +548,7 @@ class XilinxHLSModel(ModelBase):
             os.chdir(curr_dir)
 
     @copydocstring(ModelBase.build)
-    def build(self, reset=False, csim=False, synth=True, cosim=False, export=False, bitfile=False, package=False):
+    def build(self, reset=False, csim=False, synth=True, cosim=False, export=False, vsynth=False, bitfile=False, package=False):
         cwd = os.getcwd()
         os.chdir(self.config.output_dir)
         
@@ -544,6 +557,8 @@ class XilinxHLSModel(ModelBase):
             export = True
         if export:
             synth=True
+        if bitfile and vsynth:
+            logger.warn('vsynth and bitfile both set to "True". Both steps will run, but only one may be necessary')
 
         rval = True
         hls_tool = get_hls()
@@ -562,6 +577,17 @@ class XilinxHLSModel(ModelBase):
             if(success > 0):
                 logger.error("build failed, check logs")
                 rval = False
+            if success == 0 and vsynth:
+                cmd = 'vivado -mode batch -source vivado_synth.tcl > vivado_build.log'
+                start = datetime.datetime.now()
+                logger.info(f'build starting {start:%H:%M:%S}')
+                logger.debug(f'build invoking {hls_tool} with command "{cmd}"')
+                success = os.system(cmd)
+                stop = datetime.datetime.now()
+                logger.info(f'build finished {stop:%H:%M:%S} - took {str(stop-start)}')
+                if(success > 0):
+                    logger.error("build failed, check logs")
+                    rval = False
             if success == 0 and bitfile:
                 if self.config.accelerator_config is None:
                     logger.error('bitfile was requested but no accelerator_config found')
@@ -594,6 +620,10 @@ class XilinxHLSModel(ModelBase):
         report['interval'] = iib
         for key in ['lut', 'ff']:
             report[key] = full_report[key]
+
+        vsynth_report = read_vsynth_report(f'{self.config.output_dir}/vivado_synth.rpt')
+        if vsynth_report is not None:
+            report['vsynth'] = {'lut' : vsynth_report['lut'], 'ff' : vsynth_report['ff']}
         return report
 
 def auto_config(granularity='simple'):

--- a/conifer/model.py
+++ b/conifer/model.py
@@ -194,7 +194,7 @@ class ModelBase:
             assert val is not None, f'Missing expected key {key} in ensembleDict'
             setattr(self, key, val)
         trees = ensembleDict.get('trees', None)
-        assert trees is not None, f'Missing expected key {key} in ensembleDict'
+        assert trees is not None, f'Missing expected key trees in ensembleDict'
         self.trees = [[DecisionTreeBase(treeDict) for treeDict in trees_class] for trees_class in trees]
 
         def _make_stamp():
@@ -220,7 +220,7 @@ class ModelBase:
                 self._metadata = [metadata]
 
     def sparsity(self):
-        s = sum([sum([tree.sparsity() for tree in tree_c]) for tree_c in self.trees])
+        s = sum([sum([1 - (tree.n_nodes() - tree.n_leaves()) / (2 ** self.max_depth - 1) for tree in tree_c]) for tree_c in self.trees])
         n = sum([len(tree_c) for tree_c in self.trees])
         return s / n
 


### PR DESCRIPTION
This PR brings some miscellaneous quality of life improvements from the `performance_estimates` branch that are not related to the performance estimates themselves.

- Don't pad trees automatically when `unroll` is `False` for `xilinxhls` backend
- Add Vivado synthesis option to `xilinxhls` backend
- Add some utilities for model inspection: depth, sparsity
- Make HLS/HDL report reading more robust
- Don't create the `vivadohls` and `vitishls` backends, just use `xilinxhls`. Tool discovery is still automatic (so either Vivado HLS or Vitis HLS will be used automatically). This creation of the backends previously prevents `XilinxHLSModel` from being `pickle`-able, which is useful in some cases