### PR TITLE
Add expression balancing for xilinxhls backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ print(fpu.get_info())
     ```
 1. Go into the Conifer project directory: `cd conifer`
 1. Install the python development dependencies: `pip install -r dev_requirements.txt`
-1. Run an example: `PYTHONPATH="$(pwd):${PYTHONPATH}" && python examples/sklearn_to_cpp.py`
+1. Run an example: `export PYTHONPATH="$(pwd):${PYTHONPATH}" && python examples/sklearn_to_cpp.py`
 1. Run a single unit test: `pytest tests/test_multiclass.py`
 1. Run all the unit tests: `pytest`
 

--- a/conifer/backends/xilinxhls/hls-template/firmware/BDT_unrolled.cpp
+++ b/conifer/backends/xilinxhls/hls-template/firmware/BDT_unrolled.cpp
@@ -2,7 +2,7 @@
 #include "parameters.h"
 
 template<>
-void BDT::BDT<n_trees, n_classes, input_arr_t, score_t, threshold_t>::tree_scores(input_arr_t x, score_t scores[n_trees][fn_classes(n_classes)]) const {
+void BDT::BDT<n_trees, n_classes, input_arr_t, score_t, threshold_t>::tree_scores(input_arr_t x, score_t scores[fn_classes(n_classes)][n_trees]) const {
   // conifer insert tree_scores
 }
 

--- a/conifer/backends/xilinxhls/writer.py
+++ b/conifer/backends/xilinxhls/writer.py
@@ -139,7 +139,7 @@ class XilinxHLSModel(ModelBase):
                     newline = ''
                     for it, trees in enumerate(self.trees):
                         for ic, tree in enumerate(trees):
-                            newline += f'  scores[{it}][{ic}] = tree_{it}_{ic}.decision_function(x);\n'
+                            newline += f'  scores[{ic}][{it}] = tree_{ic}_{it}.decision_function(x);\n'
                 else:
                     newline = line
                 fout.write(newline)
@@ -227,7 +227,7 @@ class XilinxHLSModel(ModelBase):
             for iclass, tree in enumerate(trees):
                 fout.write(f'static const BDT::Tree<{itree*nc+iclass}, {tree.n_nodes()}, {tree.n_leaves()}')
                 fout.write(f', input_arr_t, score_t, threshold_t>')
-                fout.write(f' tree_{itree}_{iclass} = {{\n')
+                fout.write(f' tree_{iclass}_{itree} = {{\n')
                 # loop over fields
                 for ifield, field in enumerate(tree_fields):
                     newline = '    {'

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,3 +6,4 @@ scikit-learn
 xgboost<2.0.0
 pybind11
 ydf
+pandas


### PR DESCRIPTION
## PR Description
This PR is addressing issue https://github.com/thesps/conifer/issues/66.
Main changes:
 - In commit 099599d0a20a5a0ba7233a7a9bbbf3186eeb32a0 I am implementing a _tree reduction_ method similar to what is done in `hlt4ml` (see [these lines](https://github.com/fastmachinelearning/hls4ml/blob/7855db2d42967766901a6fcf1c170cb1b5c63430/hls4ml/templates/vivado/nnet_utils/nnet_common.h#L28-L71))
 - The method is used when summing the tree scores in `backends/xilinxhls/firmware/BDT_unrolled.h`
 - For this to work I had to reverse the indexes of the `score_t scores` array, from:
   ```
   score_t scores[n_trees][fn_classes(n_classes)];
   ```
   to
   ```
   score_t scores[fn_classes(n_classes)][n_trees];
   ```

These changes bring a notable improvements in latency (and partially in resource consumption) when using the `AP_SAT` flag in the BDT `ScorePrecision`, while maintaining performances identical to the current version of _conifer_ in terms of BDT score.

Additionally, in commit bffd3a6125e31f68cce29ffefeb1a00d32343b8f I fixed a typo in the "Development instructions" and added `pandas` to the `dev_requirements.txt` file.


## PR Validation
The following tests are done with:
 - xgboost `v1.7.5`
 - Vitis_LHS `v2023.2`
 - Binary classification BDT with 327 trees and max_depth = 4

Latency/Resources table:

| Conifer version | ScorePrecision                      | vsynth LUT | vsynth FF | Latency |
|--------         |--------                             |--------    |--------   |-------- |
| `master`  | `ap_fixed<11,4,AP_RND_CONV,AP_SAT>` | 51936      | 5032      | 133     |
| This PR    | `ap_fixed<11,4,AP_RND_CONV,AP_SAT>` | 51163      | 4489      | 9       |
|--------     |--------                             |--------    |--------   |-------- |
| `master`  | `ap_fixed<11,4,AP_RND_CONV>`        | 43329      | 3542      | 4       |
| This PR    | `ap_fixed<11,4,AP_RND_CONV>`        | 42988      | 3800      | 4       |

Score plots:

<img src="https://github.com/thesps/conifer/assets/7822641/fe82f8a4-ad33-409c-b000-40adeb401aeb" width="400" height="300">
<img src="https://github.com/thesps/conifer/assets/7822641/a06f82f4-30ea-402f-9a02-7f65c56e10a8" width="400" height="300">


