### PR TITLE
backend fix + xgboost 2 support

### DIFF
--- a/conifer/backends/cpp/include/conifer.h
+++ b/conifer/backends/cpp/include/conifer.h
@@ -132,7 +132,7 @@ public:
         values.at(i) += reduce<U, OpAdd<U>>(values_trees.at(i), add);
       }else{
         values.at(i) = std::accumulate(values_trees.at(i).begin(), values_trees.at(i).end(), U(init_predict_.at(i)));
-      }               
+      }
     }
 
     return values;

--- a/conifer/backends/cpp/include/conifer.h
+++ b/conifer/backends/cpp/include/conifer.h
@@ -63,7 +63,7 @@ public:
     /* Do the prediction */
     int i = 0;
     while(feature[i] != -2){ // continue until reaching leaf
-      bool comparison = x[feature[i]] <= threshold_[i];
+      bool comparison = x[feature[i]] < threshold_[i];
       i = comparison ? children_left[i] : children_right[i];
     }
     return value_[i];

--- a/conifer/backends/fpu/src/fpu.h
+++ b/conifer/backends/fpu/src/fpu.h
@@ -79,7 +79,7 @@ T dynamic_scaler(float x, float s){
   #pragma HLS pipeline
   float y_f = x * s;
   return (T) y_f;
-} 
+}
 
 template<class T, class U, int FEATBITS, int ADDRBITS, int CLASSBITS, int NVARS, int NNODES, int NTE>
 void FPU_df(T X[NVARS], U& y, DecisionNode<T,U,FEATBITS,ADDRBITS,CLASSBITS> nodes[NTE][NNODES]){

--- a/conifer/backends/fpu/src/fpu.h
+++ b/conifer/backends/fpu/src/fpu.h
@@ -68,7 +68,7 @@ void TreeEngine(T X[NVARS], DecisionNode<T,U,FEATBITS,ADDRBITS,CLASSBITS> nodes[
   auto node = nodes[i];
   node_loop : while(!node.is_leaf){
     #pragma HLS pipeline
-    i = X[node.feature] <= node.threshold ? node.child_left : node.child_right;
+    i = X[node.feature] < node.threshold ? node.child_left : node.child_right;
     node = nodes[i];
   }
   y = node.score;

--- a/conifer/backends/vhdl/firmware/Tree.vhd
+++ b/conifer/backends/vhdl/firmware/Tree.vhd
@@ -49,7 +49,7 @@ begin
       begin
         -- Compare feature for this node to threshold for this node
         if rising_edge(clk) then
-          comparison(i) <= X(iFeature(i)) <= threshold(i);
+          comparison(i) <= X(iFeature(i)) < threshold(i);
         end if;
       end process;
     end generate NonLeaf;

--- a/conifer/backends/vhdl/firmware/Tree.vhd
+++ b/conifer/backends/vhdl/firmware/Tree.vhd
@@ -74,7 +74,7 @@ begin
 
   -- do all the node activations
   -- the root node is always active
-  activation(0) <= true; 
+  activation(0) <= true;
   GenAct:
   for i in 1 to nNodes-1 generate
     -- the root node is always active
@@ -85,7 +85,7 @@ begin
         if rising_edge(clk) then
           activation(i) <= comparisonPipe(depth(i))(iParent(i)) and activation(iParent(i));
         end if;
-      end process;    
+      end process;
     end generate LeftChild;
     RightChild:
     if i = iChildRight(iParent(i)) generate
@@ -94,7 +94,7 @@ begin
         if rising_edge(clk) then
           activation(i) <= (not comparisonPipe(depth(i))(iParent(i))) and activation(iParent(i));
         end if;
-      end process;    
+      end process;
     end generate RightChild;
   end generate GenAct;
 

--- a/conifer/backends/xilinxhls/firmware/BDT_rolled.h
+++ b/conifer/backends/xilinxhls/firmware/BDT_rolled.h
@@ -68,7 +68,7 @@ public:
       // Only non-leaf nodes do comparisons
       // negative values mean is a leaf (sklearn: -2)
       if(feature[i] >= 0){
-        comparison[i] = x[feature[i]] <= threshold[i];
+        comparison[i] = x[feature[i]] < threshold[i];
       }else{
         comparison[i] = true;
       }

--- a/conifer/backends/xilinxhls/firmware/BDT_unrolled.h
+++ b/conifer/backends/xilinxhls/firmware/BDT_unrolled.h
@@ -83,7 +83,7 @@ public:
       // Only non-leaf nodes do comparisons
       // negative values mean is a leaf (sklearn: -2)
       if(feature[i] >= 0){
-        comparison[i] = x[feature[i]] <= threshold[i];
+        comparison[i] = x[feature[i]] < threshold[i];
       }else{
         comparison[i] = true;
       }

--- a/conifer/converters/xgboost.py
+++ b/conifer/converters/xgboost.py
@@ -1,8 +1,9 @@
-import numpy as np
 import json
 import xgboost as xgb
 import pandas
+from packaging import version
 from typing import Union
+__xgb_version = version.parse(xgb.__version__)
 
 def convert(bdt : Union[xgb.core.Booster, xgb.XGBClassifier, xgb.XGBRegressor]):
     assert isinstance(bdt, (xgb.core.Booster, xgb.XGBClassifier, xgb.XGBRegressor))
@@ -12,20 +13,24 @@ def convert(bdt : Union[xgb.core.Booster, xgb.XGBClassifier, xgb.XGBRegressor]):
       bst = bdt.get_booster()
     meta = json.loads(bst.save_config())
     updater = meta.get('learner').get('gradient_booster').get('gbtree_train_param').get('updater').split(',')[0]
-    max_depth = int(meta.get('learner').get('gradient_booster').get('updater').get(updater).get('train_param').get('max_depth'))
+    if __xgb_version >= version.parse('2'):
+      max_depth = int(meta.get('learner').get('gradient_booster').get('tree_train_param').get('max_depth'))
+    else:
+      updater = meta.get('learner').get('gradient_booster').get('gbtree_train_param').get('updater').split(',')[0]
+      max_depth = int(meta.get('learner').get('gradient_booster').get('updater').get(updater).get('train_param').get('max_depth'))
     n_classes = int(meta.get('learner').get('learner_model_param').get('num_class'))
     fn_classes = 1 if n_classes == 0 else n_classes # the number of learners
     n_classes = 2 if n_classes == 0 else n_classes # the actual number of classes
     n_trees = int(int(meta.get('learner').get('gradient_booster').get('gbtree_model_param').get('num_trees')) / fn_classes)
-    n_features = int(meta['learner']['learner_model_param']['num_feature'])
+    n_features = int(meta.get('learner').get('learner_model_param').get('num_feature'))
     ensembleDict = {'max_depth' : max_depth,
                     'n_trees' : n_trees,
                     'n_classes' : n_classes,
                     'n_features' : n_features,
                     'trees' : [],
-                    'init_predict' : [0] * n_classes,
+                    'init_predict' : [0] * fn_classes,
                     'norm' : 1}
-    
+
     feature_names = {}
     if bst.feature_names is None:
       for i in range(n_features):

--- a/conifer/converters/xgboost.py
+++ b/conifer/converters/xgboost.py
@@ -47,6 +47,7 @@ def convert(bdt : Union[xgb.core.Booster, xgb.XGBClassifier, xgb.XGBRegressor]):
             tree = treeToDict(tree, feature_names)
             treesl.append(tree)
         ensembleDict['trees'].append(treesl)
+    ensembleDict["feature_names"] = feature_names
     return ensembleDict
 
 def treeToDict(tree : pandas.DataFrame, feature_names):

--- a/conifer/model.py
+++ b/conifer/model.py
@@ -97,7 +97,7 @@ class DecisionTreeBase:
       node_id = f'{tree_id}_{i}'
       l = f'{tree_id}_{self.children_left[i]}'
       r = f'{tree_id}_{self.children_right[i]}'
-      label = f'x[{self.feature[i]}] <= {self.threshold[i]:.2f}' if self.feature[i] != -2 else f'{self.value[i]:.2f}'
+      label = f'x[{self.feature[i]}] < {self.threshold[i]:.2f}' if self.feature[i] != -2 else f'{self.value[i]:.2f}'
       sg.add_node(pydot.Node(node_id, label=label))
       if self.children_left[i] != -1:
         sg.add_edge(pydot.Edge(node_id, l,))
@@ -119,7 +119,7 @@ class DecisionTreeBase:
     for i, x in enumerate(X):
       n = 0
       while self.feature[n] != -2:
-        comp = x[self.feature[n]] <= self.threshold[n]
+        comp = x[self.feature[n]] < self.threshold[n]
         n = self.children_left[n] if comp else self.children_right[n]
       y[i] = n
     return y

--- a/conifer/model.py
+++ b/conifer/model.py
@@ -34,9 +34,9 @@ class DecisionTreeBase:
     _tree_fields = ['feature', 'threshold', 'value', 'children_left', 'children_right']
     def __init__(self, treeDict):
         for key in DecisionTreeBase._tree_fields:
-        val = treeDict.get(key, None)
-        assert val is not None, f"Missing expected key {key} in treeDict"
-        setattr(self, key, val)
+            val = treeDict.get(key, None)
+            assert val is not None, f"Missing expected key {key} in treeDict"
+            setattr(self, key, val)
 
     def n_nodes(self):
         return len(self.feature)
@@ -47,26 +47,26 @@ class DecisionTreeBase:
     def max_depth(self):
         parents = [0] * self.n_nodes()
         for i in range(self.n_nodes()):
-        j = self.children_left[i]
-        if j != -1:
-            parents[j] = i
-        k = self.children_right[i]
-        if k != -1:
-            parents[k] = i
+            j = self.children_left[i]
+            if j != -1:
+                parents[j] = i
+            k = self.children_right[i]
+            if k != -1:
+                parents[k] = i
         parents[0] = -1
         depth = [0] * self.n_nodes()
         max_depth = 0
         for i in range(self.n_nodes()):
-        depth = 0
-        parent = parents[i]
-        while parent != -1:
-            depth += 1
-            parent = parents[parent]
-        max_depth = depth if depth > max_depth else max_depth
+            depth = 0
+            parent = parents[i]
+            while parent != -1:
+                depth += 1
+                parent = parents[parent]
+            max_depth = depth if depth > max_depth else max_depth
         return max_depth
 
     def sparsity(self):
-        return 1 - (self.n_nodes() - self.n_leaves()) / (2 ** self.max_depth() - 1)
+            return 1 - (self.n_nodes() - self.n_leaves()) / (2 ** self.max_depth() - 1)
 
     def draw(self, filename : str = None, graph=None, tree_id=None):
         '''
@@ -75,41 +75,41 @@ class DecisionTreeBase:
         Parameters
         ----------
         filename: string
-            filename to save to, with any extension supported by pydot write
+                filename to save to, with any extension supported by pydot write
 
         graph:
-            existing pydot graph to add to
+                existing pydot graph to add to
 
         tree_id:
-            ID of the tree within an ensemble
+                ID of the tree within an ensemble
 
         Returns
         ----------
         pydot Dot graph object
         '''
         if not _check_pydot():
-            raise ImportError('Could not import pydot. Install Graphviz and pydot to draw trees')
+                raise ImportError('Could not import pydot. Install Graphviz and pydot to draw trees')
         graph = pydot.Dot(graph_type='graph') if graph is None else graph
         tree_id = '' if tree_id is None else tree_id
         sg = pydot.Cluster(tree_id, label=tree_id, peripheries=0 if tree_id=='' else 1)
         graph.add_subgraph(sg)
         for i in range(self.n_nodes()):
-        node_id = f'{tree_id}_{i}'
-        l = f'{tree_id}_{self.children_left[i]}'
-        r = f'{tree_id}_{self.children_right[i]}'
-        label = f'x[{self.feature[i]}] < {self.threshold[i]:.2f}' if self.feature[i] != -2 else f'{self.value[i]:.2f}'
-        sg.add_node(pydot.Node(node_id, label=label))
-        if self.children_left[i] != -1:
-            sg.add_edge(pydot.Edge(node_id, l,))
-        if self.children_right[i] != -1:
-            sg.add_edge(pydot.Edge(node_id, r,))
+            node_id = f'{tree_id}_{i}'
+            l = f'{tree_id}_{self.children_left[i]}'
+            r = f'{tree_id}_{self.children_right[i]}'
+            label = f'x[{self.feature[i]}] < {self.threshold[i]:.2f}' if self.feature[i] != -2 else f'{self.value[i]:.2f}'
+            sg.add_node(pydot.Node(node_id, label=label))
+            if self.children_left[i] != -1:
+                sg.add_edge(pydot.Edge(node_id, l,))
+            if self.children_right[i] != -1:
+                sg.add_edge(pydot.Edge(node_id, r,))
         if filename is not None:
-            _, extension = os.path.splitext(filename)
-            if not extension:
-                extension = 'png'
-            else:
-                extension = extension[1:]
-            graph.write(filename, format=extension)
+                _, extension = os.path.splitext(filename)
+                if not extension:
+                        extension = 'png'
+                else:
+                        extension = extension[1:]
+                graph.write(filename, format=extension)
 
         return graph
 
@@ -117,11 +117,11 @@ class DecisionTreeBase:
         assert len(X.shape) == 2, 'Expected 2D input'
         y = np.zeros(X.shape[0], dtype='int')
         for i, x in enumerate(X):
-        n = 0
-        while self.feature[n] != -2:
-            comp = x[self.feature[n]] < self.threshold[n]
-            n = self.children_left[n] if comp else self.children_right[n]
-        y[i] = n
+            n = 0
+            while self.feature[n] != -2:
+                comp = x[self.feature[n]] < self.threshold[n]
+                n = self.children_left[n] if comp else self.children_right[n]
+            y[i] = n
         return y
 
     def decision_function(self, X):

--- a/conifer/model.py
+++ b/conifer/model.py
@@ -357,10 +357,8 @@ class ModelBase:
             import matplotlib.pyplot as plt
         except ImportError:
             raise Exception("matplotlib not found. Please install matplotlib")
-        value = np.array([tree['value'] for trees in self._ensembleDict['trees']
-                         for tree in trees]).flatten()
-        threshold = np.array(
-            [tree['threshold'] for trees in self._ensembleDict['trees'] for tree in trees]).flatten()
+        value = np.concatenate([np.array(tree['value']) for trees in self._ensembleDict['trees'] for tree in trees])
+        threshold = np.concatenate([np.array(tree['threshold']) for trees in self._ensembleDict['trees'] for tree in trees])
         hv, bv = np.histogram(value, bins=bins)
         wv = bv[1] - bv[0]
         ht, bt = np.histogram(threshold, bins=bins)

--- a/conifer/model.py
+++ b/conifer/model.py
@@ -219,6 +219,8 @@ class ModelBase:
             else:
                 self._metadata = [metadata]
 
+        self._ensembleDict = ensembleDict
+
     def sparsity(self):
         s = sum([sum([1 - (tree.n_nodes() - tree.n_leaves()) / (2 ** self.max_depth - 1) for tree in tree_c]) for tree_c in self.trees])
         n = sum([len(tree_c) for tree_c in self.trees])

--- a/conifer/model.py
+++ b/conifer/model.py
@@ -26,108 +26,108 @@ def _check_pydot():
         return True
     except OSError:
         return False
-    
+
 class DecisionTreeBase:
-  '''
-  Conifer DecisionTreeBase representation class
-  '''
-  _tree_fields = ['feature', 'threshold', 'value', 'children_left', 'children_right']
-  def __init__(self, treeDict):
-    for key in DecisionTreeBase._tree_fields:
-      val = treeDict.get(key, None)
-      assert val is not None, f"Missing expected key {key} in treeDict"
-      setattr(self, key, val)
-
-  def n_nodes(self):
-    return len(self.feature)
-
-  def n_leaves(self):
-    return len([n for n in self.feature if n == -2])
-  
-  def max_depth(self):
-    parents = [0] * self.n_nodes()
-    for i in range(self.n_nodes()):
-      j = self.children_left[i]
-      if j != -1:
-        parents[j] = i
-      k = self.children_right[i]
-      if k != -1:
-        parents[k] = i
-    parents[0] = -1
-    depth = [0] * self.n_nodes()
-    max_depth = 0
-    for i in range(self.n_nodes()):
-      depth = 0
-      parent = parents[i]
-      while parent != -1:
-        depth += 1
-        parent = parents[parent]
-      max_depth = depth if depth > max_depth else max_depth
-    return max_depth
-
-  def sparsity(self):
-      return 1 - (self.n_nodes() - self.n_leaves()) / (2 ** self.max_depth() - 1)
-
-  def draw(self, filename : str = None, graph=None, tree_id=None):
     '''
-    Draw a pydot graph of the decision tree
-
-    Parameters
-    ----------
-    filename: string
-        filename to save to, with any extension supported by pydot write
-
-    graph:
-        existing pydot graph to add to
-
-    tree_id:
-        ID of the tree within an ensemble
-
-    Returns
-    ----------
-    pydot Dot graph object
+    Conifer DecisionTreeBase representation class
     '''
-    if not _check_pydot():
-        raise ImportError('Could not import pydot. Install Graphviz and pydot to draw trees')
-    graph = pydot.Dot(graph_type='graph') if graph is None else graph
-    tree_id = '' if tree_id is None else tree_id
-    sg = pydot.Cluster(tree_id, label=tree_id, peripheries=0 if tree_id=='' else 1)
-    graph.add_subgraph(sg)
-    for i in range(self.n_nodes()):
-      node_id = f'{tree_id}_{i}'
-      l = f'{tree_id}_{self.children_left[i]}'
-      r = f'{tree_id}_{self.children_right[i]}'
-      label = f'x[{self.feature[i]}] < {self.threshold[i]:.2f}' if self.feature[i] != -2 else f'{self.value[i]:.2f}'
-      sg.add_node(pydot.Node(node_id, label=label))
-      if self.children_left[i] != -1:
-        sg.add_edge(pydot.Edge(node_id, l,))
-      if self.children_right[i] != -1:
-        sg.add_edge(pydot.Edge(node_id, r,))
-    if filename is not None:
-        _, extension = os.path.splitext(filename)
-        if not extension:
-            extension = 'png'
-        else:
-            extension = extension[1:]
-        graph.write(filename, format=extension)
+    _tree_fields = ['feature', 'threshold', 'value', 'children_left', 'children_right']
+    def __init__(self, treeDict):
+        for key in DecisionTreeBase._tree_fields:
+        val = treeDict.get(key, None)
+        assert val is not None, f"Missing expected key {key} in treeDict"
+        setattr(self, key, val)
 
-    return graph
+    def n_nodes(self):
+        return len(self.feature)
 
-  def apply(self, X):
-    assert len(X.shape) == 2, 'Expected 2D input'
-    y = np.zeros(X.shape[0], dtype='int')
-    for i, x in enumerate(X):
-      n = 0
-      while self.feature[n] != -2:
-        comp = x[self.feature[n]] < self.threshold[n]
-        n = self.children_left[n] if comp else self.children_right[n]
-      y[i] = n
-    return y
+    def n_leaves(self):
+        return len([n for n in self.feature if n == -2])
 
-  def decision_function(self, X):
-    assert len(X.shape) == 2, 'Expected 2D input'
-    yi = self.apply(X)
-    return np.array(self.value)[yi]
+    def max_depth(self):
+        parents = [0] * self.n_nodes()
+        for i in range(self.n_nodes()):
+        j = self.children_left[i]
+        if j != -1:
+            parents[j] = i
+        k = self.children_right[i]
+        if k != -1:
+            parents[k] = i
+        parents[0] = -1
+        depth = [0] * self.n_nodes()
+        max_depth = 0
+        for i in range(self.n_nodes()):
+        depth = 0
+        parent = parents[i]
+        while parent != -1:
+            depth += 1
+            parent = parents[parent]
+        max_depth = depth if depth > max_depth else max_depth
+        return max_depth
+
+    def sparsity(self):
+        return 1 - (self.n_nodes() - self.n_leaves()) / (2 ** self.max_depth() - 1)
+
+    def draw(self, filename : str = None, graph=None, tree_id=None):
+        '''
+        Draw a pydot graph of the decision tree
+
+        Parameters
+        ----------
+        filename: string
+            filename to save to, with any extension supported by pydot write
+
+        graph:
+            existing pydot graph to add to
+
+        tree_id:
+            ID of the tree within an ensemble
+
+        Returns
+        ----------
+        pydot Dot graph object
+        '''
+        if not _check_pydot():
+            raise ImportError('Could not import pydot. Install Graphviz and pydot to draw trees')
+        graph = pydot.Dot(graph_type='graph') if graph is None else graph
+        tree_id = '' if tree_id is None else tree_id
+        sg = pydot.Cluster(tree_id, label=tree_id, peripheries=0 if tree_id=='' else 1)
+        graph.add_subgraph(sg)
+        for i in range(self.n_nodes()):
+        node_id = f'{tree_id}_{i}'
+        l = f'{tree_id}_{self.children_left[i]}'
+        r = f'{tree_id}_{self.children_right[i]}'
+        label = f'x[{self.feature[i]}] < {self.threshold[i]:.2f}' if self.feature[i] != -2 else f'{self.value[i]:.2f}'
+        sg.add_node(pydot.Node(node_id, label=label))
+        if self.children_left[i] != -1:
+            sg.add_edge(pydot.Edge(node_id, l,))
+        if self.children_right[i] != -1:
+            sg.add_edge(pydot.Edge(node_id, r,))
+        if filename is not None:
+            _, extension = os.path.splitext(filename)
+            if not extension:
+                extension = 'png'
+            else:
+                extension = extension[1:]
+            graph.write(filename, format=extension)
+
+        return graph
+
+    def apply(self, X):
+        assert len(X.shape) == 2, 'Expected 2D input'
+        y = np.zeros(X.shape[0], dtype='int')
+        for i, x in enumerate(X):
+        n = 0
+        while self.feature[n] != -2:
+            comp = x[self.feature[n]] < self.threshold[n]
+            n = self.children_left[n] if comp else self.children_right[n]
+        y[i] = n
+        return y
+
+    def decision_function(self, X):
+        assert len(X.shape) == 2, 'Expected 2D input'
+        yi = self.apply(X)
+        return np.array(self.value)[yi]
 
 class ConfigBase:
     '''
@@ -280,7 +280,7 @@ class ModelBase:
         Compilation is carried out by the model backend
         '''
         raise NotImplementedError
-    
+
     def draw(self, filename=None):
         '''
         Draw a pydot graph of the decision tree
@@ -314,15 +314,15 @@ class ModelBase:
         '''
         Compute the decision function of `X`.
         The backend performs the actual computation
-        
+
         Parameters
         ----------
         X: array-like of shape (n_samples, n_features)
             Input sample
-        
+
         Returns
-        ----------    
-        score: ndarray of shape (n_samples, n_classes) or (n_samples,)   
+        ----------
+        score: ndarray of shape (n_samples, n_classes) or (n_samples,)
 
         '''
         assert len(X.shape) == 2, 'Expected 2D input'
@@ -344,11 +344,11 @@ class ModelBase:
         Parameters
         ----------
         kwargs: keyword arguments of backend build method
-        
+
         Returns
-        ----------    
+        ----------
         success: bool
-                 True if the build completed successfuly, otherwise False  
+                 True if the build completed successfuly, otherwise False
         '''
         raise NotImplementedError
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,7 +3,7 @@ onnxruntime
 scipy
 onnxmltools
 scikit-learn
-xgboost<2.0.0
+xgboost
 pybind11
 ydf
 pandas


### PR DESCRIPTION
The main issue that this PR is solving is the following:

In XGBoost, the cuts on the inputs are \<cut and \>=cut while for all the backends in Conifer is the opposite ( \<=cut and \>cut ).
This usually is irrelevant but when the input is binary it makes a lot of difference, not allowing to pass any cut for that feature.

So I changed the comparison in the decision function methods of all the backends to be in agreement with XGBoost.

Since then, I tested the python, cpp and vivado backend on xgboost (both v1 and v2, both XGBClassifier and Booster objects) and yggdrasil models and everything is okay. We should test also the vhdl and fpu backend and the sklearn, tmva and the onnx models.

I tried to run all the tests but a lot of them complained about not having pybind11 compiled, I will investigate to ensure that this PR passes all the tests.

Other minor fixes are the following:
- Added support for xgboost2 (practically the same of the xgb2 branch)
- Fixed the profile method in ModelBase
- Added the dictionary map between the feature name and the feature numbering to the ensembleDict to allow an easier inspection of the model.