### PR TITLE
Add support for yggdrasil IsolationForest

### DIFF
--- a/conifer/backends/cpp/include/conifer.h
+++ b/conifer/backends/cpp/include/conifer.h
@@ -90,6 +90,7 @@ private:
   unsigned int n_classes;
   unsigned int n_trees;
   unsigned int n_features;
+  double norm;
   std::vector<double> init_predict;
   std::vector<U> init_predict_;
   // vector of decision trees: outer dimension tree, inner dimension class
@@ -99,7 +100,7 @@ private:
 public:
 
   // Define how to read this class to/from JSON
-  NLOHMANN_DEFINE_TYPE_INTRUSIVE(BDT, n_classes, n_trees, n_features, init_predict, trees);
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE(BDT, n_classes, n_trees, n_features, norm, init_predict, trees);
 
   BDT(std::string filename){
     /* Construct the BDT from conifer cpp backend JSON file */
@@ -132,7 +133,8 @@ public:
         values.at(i) += reduce<U, OpAdd<U>>(values_trees.at(i), add);
       }else{
         values.at(i) = std::accumulate(values_trees.at(i).begin(), values_trees.at(i).end(), U(init_predict_.at(i)));
-      }               
+      }
+      values.at(i) *= (U) norm;
     }
 
     return values;

--- a/conifer/converters/ydf.py
+++ b/conifer/converters/ydf.py
@@ -2,6 +2,7 @@
 
 from typing import List, Any, Dict, Union
 import dataclasses
+import math
 
 import ydf
 
@@ -12,25 +13,39 @@ ConiferModel = Dict[str, Any]
 def convert(model: ydf.GenericModel) -> ConiferModel:
     """Converts a YDF model into a Conifer model."""
 
-    if model.task() != ydf.Task.CLASSIFICATION:
+    if model.task() not in [ydf.Task.CLASSIFICATION, ydf.Task.ANOMALY_DETECTION]:
         raise ValueError(
-            f"Classification YDF model expected. Instead, found task {model.task()!r}"
+            f"Classification or Anomaly Detection YDF model expected. Instead, found task {model.task()!r}"
         )
-    if isinstance(model, ydf.GradientBoostedTreesModel):
-        return _convert_gbt(model)
+    if isinstance(model, (ydf.GradientBoostedTreesModel, ydf.IsolationForestModel)):
+        return _convert_forest(model)
     raise ValueError(f"Not supported YDF model type {type(model)}")
 
 
-def _convert_gbt(model: ydf.GradientBoostedTreesModel) -> ConiferModel:
-    """Converts a YDF GBT model into a Conifer model."""
+def _convert_forest(model: Union[ydf.GradientBoostedTreesModel, ydf.IsolationForestModel]) -> ConiferModel:
+    """Converts a YDF model into a Conifer model."""
 
+    is_gbtm = isinstance(model, ydf.GradientBoostedTreesModel)
+    is_ifm = isinstance(model, ydf.IsolationForestModel)
     src_trees = model.get_all_trees()
     column_idx_to_feature_idx = _feature_mapping(model)
     max_depth = _get_max_depth(src_trees)
-    initial_predictions = model.initial_predictions().tolist()
-    label_classes = model.label_classes()
-    num_trees_per_iter = len(initial_predictions)
-    num_iterations = model.num_trees() // num_trees_per_iter
+
+    if is_gbtm:
+        label_classes = model.label_classes()
+        initial_predictions = model.initial_predictions().tolist()
+        num_trees_per_iter = len(initial_predictions)
+        num_iterations = model.num_trees() // num_trees_per_iter
+        norm = 1.
+    elif is_ifm:
+        label_classes = [0]
+        initial_predictions = [0]
+        num_trees_per_iter = 1
+        num_iterations = model.num_trees()
+        num_examples_per_trees = model.get_tree(tree_idx=0).root.value.num_examples_without_weight
+        norm = - 1. / (num_iterations * preiss_average_path_length(num_examples_per_trees))
+    else:
+        assert False
 
     # Conifer dictionary without the "trees" field.
     base_conifer_dict = {
@@ -39,7 +54,7 @@ def _convert_gbt(model: ydf.GradientBoostedTreesModel) -> ConiferModel:
         "n_classes": len(label_classes),
         "n_features": len(column_idx_to_feature_idx),
         "init_predict": initial_predictions,
-        "norm": 1,
+        "norm": norm,
     }
 
     # Converts trees
@@ -109,24 +124,32 @@ class ConiferTreeBuilder:
     def set_tree(
         self, tree: ydf.tree.Tree, column_idx_to_feature_idx: FeatureMapping
     ) -> None:
-        self._add_node(tree.root, column_idx_to_feature_idx)
+        self._add_node(tree.root, column_idx_to_feature_idx, 0)
 
     def _add_node(
         self,
         node: ydf.tree.AbstractNode,
         column_idx_to_feature_idx: FeatureMapping,
+        depth: int,
     ) -> None:
         if node.is_leaf:
             # A leaf node
             assert isinstance(node, ydf.tree.Leaf)
 
-            if not isinstance(node.value, ydf.tree.RegressionValue):
-                raise ValueError(f"No supported leaf value {node.value!r}")
             self.feature.append(-2)
             self.threshold.append(-2.0)
             self.children_left.append(-1)
             self.children_right.append(-1)
-            self.value.append(node.value.value)
+            value = 0
+            if isinstance(node.value, ydf.tree.RegressionValue):
+                value = node.value.value
+            elif isinstance(node.value, ydf.tree.AnomalyDetectionValue):
+                num_examples = node.value.num_examples_without_weight
+                value = depth + preiss_average_path_length(num_examples)
+            else:
+                raise ValueError(f"No supported leaf value {node.value!r}")
+
+            self.value.append(value)
 
         else:
             # A non leaf node
@@ -154,7 +177,23 @@ class ConiferTreeBuilder:
 
             # Set children nodes
             self.children_left[node_idx] = self.num_nodes()
-            self._add_node(node.neg_child, column_idx_to_feature_idx)
+            self._add_node(node.neg_child, column_idx_to_feature_idx, depth+1)
 
             self.children_right[node_idx] = self.num_nodes()
-            self._add_node(node.pos_child, column_idx_to_feature_idx)
+            self._add_node(node.pos_child, column_idx_to_feature_idx, depth+1)
+
+def preiss_average_path_length(num_examples: int) -> float:
+    # Implementation from https://github.com/google/yggdrasil-decision-forests/blob/v1.10.0/yggdrasil_decision_forests/model/isolation_forest/isolation_forest.cc#L58
+    assert num_examples > 0, "num_examples must be greater than 0"
+
+    # Harmonic number approximation (from "Isolation Forest" by Liu et al.)
+    def H(x: float) -> float:
+        euler_constant = 0.5772156649
+        return math.log(x) + euler_constant
+
+    if num_examples > 2:
+        return 2.0 * H(num_examples - 1.0) - 2.0 * (num_examples - 1.0) / num_examples
+    elif num_examples == 2:
+        return 1.0
+    else:
+        return 0.0  # To be safe

--- a/conifer/model.py
+++ b/conifer/model.py
@@ -339,7 +339,7 @@ class ModelBase:
         for it, trees in enumerate(self.trees):
             for ic, tree_c in enumerate(trees):
                 y[it, ic] = tree_c.decision_function(X)
-        y = np.transpose(np.sum(y, axis=0)) + self.init_predict
+        y = (np.transpose(np.sum(y, axis=0)) + self.init_predict) * self.norm
         return np.squeeze(y)
 
     def build(self, **kwargs):

--- a/examples/ydf_anomaly_detection.ipynb
+++ b/examples/ydf_anomaly_detection.ipynb
@@ -1,0 +1,373 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Anomaly Detection\n",
+    "\n",
+    "This example is based on the anomaly detection tutorial of yggdrasil decision forests. Go to that tutorial for a more complete introduction to anomaly detection and inspecting decision forest anomaly detectors: https://ydf.readthedocs.io/en/latest/tutorial/anomaly_detection/\n",
+    "\n",
+    "Anomaly detection techniques are non-supervised learning algorithms for identifying rare and unusual patterns in data that deviate significantly from the norm. For example, anomaly detection can be used for fraud detection, network intrusion detection, and fault diagnosis, without the need for defining of abnormal instances.\n",
+    "\n",
+    "Anomaly detection with decision forests is a straightforward but effective technique for tabular data. The model assigns an anomaly score to each data point, ranging from 0 (normal) to 1 (abnormal). Decision forests also offer interpretability tools and properties, making it easier to understand and characterize detected anomalies.\n",
+    "\n",
+    "In anomaly detection, labeled examples are used not for training but for evaluating the model. These labels ensure that the model can detect known anomalies.\n",
+    "\n",
+    "We train and evaluate two anomaly detection models on the UCI Covertype dataset, which describes forest cover types and other geographic attributes of land cells. The first model is trained on pine and willow data. Given that willow is rarer than pine, the model differentiates between them without labels. This first model will then be interpreted and characterize what constitute a pine cover type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ydf  # For learning the anomaly detection model\n",
+    "import pandas as pd  # We use Pandas to load small datasets\n",
+    "from sklearn import metrics  # Use sklearn to compute AUC\n",
+    "from ucimlrepo import fetch_ucirepo  # To download the dataset\n",
+    "import matplotlib.pyplot as plt  # For plotting\n",
+    "import seaborn as sns  # For plotting\n",
+    "import conifer # conifer\n",
+    "import logging\n",
+    "import sys\n",
+    "logging.basicConfig(stream=sys.stdout, level=logging.WARNING)\n",
+    "logger = logging.getLogger('conifer')\n",
+    "logger.setLevel(logging.DEBUG)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# https://archive.ics.uci.edu/dataset/31/covertype\n",
+    "covertype_repo = fetch_ucirepo(id=31)\n",
+    "raw_dataset = pd.concat([covertype_repo.data.features, covertype_repo.data.targets], axis=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Select the columns of interest and clean the labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = raw_dataset.copy()\n",
+    "\n",
+    "# Features of interest\n",
+    "features = [\"Elevation\", \"Aspect\", \"Slope\", \"Horizontal_Distance_To_Hydrology\",\n",
+    "            \"Vertical_Distance_To_Hydrology\", \"Horizontal_Distance_To_Roadways\",\n",
+    "            \"Hillshade_9am\", \"Hillshade_Noon\", \"Hillshade_3pm\",\n",
+    "            \"Horizontal_Distance_To_Fire_Points\"]\n",
+    "dataset = dataset[features + [\"Cover_Type\"]]\n",
+    "\n",
+    "# Covert type as text\n",
+    "dataset[\"Cover_Type\"] = dataset[\"Cover_Type\"].map({\n",
+    "    1: \"Spruce/Fir\",\n",
+    "    2: \"Lodgepole Pine\",\n",
+    "    3: \"Ponderosa Pine\",\n",
+    "    4: \"Cottonwood/Willow\",\n",
+    "    5: \"Aspen\",\n",
+    "    6: \"Douglas-fir\",\n",
+    "    7: \"Krummholz\"\n",
+    "})\n",
+    "\n",
+    "dataset.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The first model is trained on the \"filtered dataset\" than only contain spruce/fir and cottonwood/willow examples."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filtered_dataset = dataset[dataset[\"Cover_Type\"].isin([\"Spruce/Fir\", \"Cottonwood/Willow\"])]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see, the spruce/fir cover is much more common than the cottonwood/willow cover:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filtered_dataset[\"Cover_Type\"].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We train a popular anomaly detection decision forest algorithm called isolation forest.\n",
+    "\n",
+    "## Anomaly detection model\n",
+    "\n",
+    "The model trained here is a bit smaller (fewer trees and shallower) than the one from the `ydf` tutorial, to make it faster to synthesize and with a smaller FPGA footprint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = ydf.IsolationForestLearner(num_trees=50, max_depth=4, features=features).train(filtered_dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then generate \"predictions\" i.e. anomaly scores."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictions = model.predict(filtered_dataset)\n",
+    "predictions[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we plot the model anomaly score's distribution for spruce/fir and cottonwood/willow cover. We se than both distributions are \"separated\", indicating the model's ability to differentiate between the two covers.\n",
+    "\n",
+    "Note: It's important to note that since cottonwood/willow cover is less frequent, the two distributions are normalized separately. Otherwise, the cottonwood/willow distribution would appear fla"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.kdeplot(predictions[filtered_dataset[\"Cover_Type\"] == \"Spruce/Fir\"], label=\"Spruce/Fir\")\n",
+    "sns.kdeplot(predictions[filtered_dataset[\"Cover_Type\"] == \"Cottonwood/Willow\"], label=\"Cottonwood/Willow\")\n",
+    "plt.xlabel(\"predicted anomaly score\")\n",
+    "plt.ylabel(\"distribution\")\n",
+    "plt.legend()\n",
+    "None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Convert to conifer\n",
+    "\n",
+    "Firstly we'll convert the anomaly detection model to `conifer` with the C++ backend to verify that we get correct outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cfg = conifer.backends.cpp.auto_config()\n",
+    "cfg['OutputDir'] = 'prj_ydf_anomaly_detection_cpp'\n",
+    "cfg['Precision'] = 'float'\n",
+    "cnf_model_cpp = conifer.converters.convert_from_ydf(model, cfg)\n",
+    "cnf_model_cpp.compile()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make predictions with the conifer model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cnf_predictions = cnf_model_cpp.decision_function(filtered_dataset[features].to_numpy())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To compare anomaly predictions with `ydf` we have to base-two exponentiate our conifer predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'First 5 conifer predictions  : {2**cnf_predictions[:5][:,0]}')\n",
+    "print(f'First 5 yggdrasil predictions: {predictions[:5]}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot again the distribution of the anomaly score, adding the predictions from conifer. They should overlap well with the yggdrasil predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.kdeplot(predictions[filtered_dataset[\"Cover_Type\"] == \"Spruce/Fir\"], label=\"Spruce/Fir (yggdrasil)\", color='b')\n",
+    "sns.kdeplot(predictions[filtered_dataset[\"Cover_Type\"] == \"Cottonwood/Willow\"], label=\"Cottonwood/Willow (yggdrasil)\", color='orange')\n",
+    "sns.kdeplot(2**cnf_predictions[filtered_dataset[\"Cover_Type\"] == \"Spruce/Fir\"], label=\"Spruce/Fir (conifer)\", linestyle='--', color='g')\n",
+    "sns.kdeplot(2**cnf_predictions[filtered_dataset[\"Cover_Type\"] == \"Cottonwood/Willow\"], label=\"Cottonwood/Willow (conifer)\", linestyle='--', color='red')\n",
+    "plt.xlabel(\"predicted anomaly score\")\n",
+    "plt.ylabel(\"distribution\")\n",
+    "plt.legend()\n",
+    "None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## FPGA\n",
+    "\n",
+    "Now we saw that we can convert yggdrasil isolation forests and make predictions on CPU with conifer, we'll convert the same model to HLS. For that we also need to choose precisions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hls_cfg = conifer.backends.xilinxhls.auto_config(granularity='full')\n",
+    "hls_cfg['InputPrecision'] = 'ap_fixed<14,14,AP_RND_CONV,AP_SAT>'     # 14 bit integer based on the range of the input features\n",
+    "hls_cfg['ThresholdPrecision'] = 'ap_fixed<16,14,AP_RND_CONV,AP_SAT>' # 14 bit integer + 2 bit fractional to have some resolution between the features\n",
+    "hls_cfg['ScorePrecision'] = 'ap_fixed<20,11,AP_RND_CONV,AP_SAT>'     # 11 bit integer + 9 bit fractional to cover both leaf values and normalisation factor\n",
+    "cnf_model_hls = conifer.converters.convert_from_ydf(model, hls_cfg)\n",
+    "cnf_model_hls.compile()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Validate the fixed precision choices by emulating the predictions and comparing to the original"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cnf_predictions_hls = cnf_model_hls.decision_function(filtered_dataset[features].to_numpy())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.kdeplot(predictions[filtered_dataset[\"Cover_Type\"] == \"Spruce/Fir\"], label=\"Spruce/Fir (yggdrasil)\", color='b')\n",
+    "sns.kdeplot(predictions[filtered_dataset[\"Cover_Type\"] == \"Cottonwood/Willow\"], label=\"Cottonwood/Willow (yggdrasil)\", color='orange')\n",
+    "sns.kdeplot(2**cnf_predictions_hls[filtered_dataset[\"Cover_Type\"] == \"Spruce/Fir\"], label=\"Spruce/Fir (conifer)\", linestyle='--', color='g')\n",
+    "sns.kdeplot(2**cnf_predictions_hls[filtered_dataset[\"Cover_Type\"] == \"Cottonwood/Willow\"], label=\"Cottonwood/Willow (conifer)\", linestyle='--', color='red')\n",
+    "plt.xlabel(\"predicted anomaly score\")\n",
+    "plt.ylabel(\"distribution\")\n",
+    "plt.legend()\n",
+    "None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now run the HLS and HDL synthesis steps so that we can inspect the resources and latency. Check the `hls_accelerator.py` example to see how to target a supported board to produce a binary that can run on an FPGA device."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cnf_model_hls.build(synth=True, vsynth=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print the HLS and HDL Synthesis reports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cnf_model_hls.read_report()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_ydf.py
+++ b/tests/test_ydf.py
@@ -33,28 +33,37 @@ def toy_dataset(request) -> Dataset:
         raise ValueError("Unknown dataset")
 
 
-@pytest.fixture(params=["exact"])
+@pytest.fixture(params=[("exact", "GradientBoostedTreesLearner"),
+                        ("exact", "IsolationForestLearner")])
 def toy_ydf_model(toy_dataset, request) -> ydf.GenericModel:
     """Trains a YDF model on a toy dataset."""
 
-    if request.param == "exact":
+    if request.param[0] == "exact":
         extra_kwargs = {}
-    elif request.param == "oblique":
+    elif request.param[0] == "oblique":
         extra_kwargs = {"split_axis": "SPARSE_OBLIQUE"}  # TODO: Test when supported.
     else:
         assert False
 
     # See https://ydf.readthedocs.io/en/latest/py_api/GradientBoostedTreesLearner/
-    learner = ydf.GradientBoostedTreesLearner(
+    if request.param[1] == "GradientBoostedTreesLearner":
+        Learner = ydf.GradientBoostedTreesLearner
+        learner_kwargs = {"apply_link_function" : False}
+    elif request.param[1] == "IsolationForestLearner":
+        Learner = ydf.IsolationForestLearner
+        learner_kwargs = {}
+    else:
+        assert False
+
+    learner = Learner(
         label="y",
         num_trees=5,
         max_depth=6,
-        apply_link_function=False,
+        **learner_kwargs,
         **extra_kwargs,
     )
     model = learner.train({"x": toy_dataset.X, "y": toy_dataset.y})
     return model
-
 
 def test_vhdl_toy_model(toy_dataset, toy_ydf_model, tmp_path):
     # Create a conifer config
@@ -87,6 +96,8 @@ def test_hls_toy_model(toy_dataset, toy_ydf_model, tmp_path):
 
     # Check predictions
     conifer_pred = conifer_model.decision_function(toy_dataset.X_test)
+    if isinstance(toy_ydf_model, ydf.IsolationForestModel):
+        conifer_pred = 2**conifer_pred
     ydf_pred = np.squeeze(toy_ydf_model.predict({"x": toy_dataset.X_test}))
     np.testing.assert_allclose(conifer_pred, ydf_pred, atol=1e-3, rtol=1e-3)
 
@@ -103,6 +114,8 @@ def test_cpp_toy_model(toy_dataset, toy_ydf_model, tmp_path):
 
     # Check predictions
     conifer_pred = np.squeeze(conifer_model.decision_function(toy_dataset.X_test))
+    if isinstance(toy_ydf_model, ydf.IsolationForestModel):
+        conifer_pred = 2**conifer_pred
     ydf_pred = np.squeeze(toy_ydf_model.predict({"x": toy_dataset.X_test}))
     np.testing.assert_allclose(conifer_pred, ydf_pred, atol=1e-3, rtol=1e-3)
 


### PR DESCRIPTION
This PR adds support for `IsolationForestModel` from `yggdrasil`. I have been using the model trained in the [anomaly detection notebook](https://ydf.readthedocs.io/en/stable/tutorial/anomaly_detection/) from `yggdrasil` for reference, and the agreement is good for all the backends.

Leaf values are calculated at the conversion step, and model score normalisation is used for taking the average over trees and factoring in the average path length. In `yggdrasil` the [final result is](https://github.com/google/yggdrasil-decision-forests/blob/v1.10.0/yggdrasil_decision_forests/model/isolation_forest/isolation_forest.cc#L84-L85): 
```
  const float term = -average_h / denominator;
  return std::pow(2.f, term);
```

This implementation in `conifer` returns only "`term`" so for checking the behaviour or using the result, one needs to carry out the `2^term` themselves. A future `conifer` development should add functionality to add this final step.

Most of the backends were not properly supporting normalisation of the model result. This has now been added to all except the FPU, which will be a follow up since the existing scaling needs revisiting.

I plan to add a test before merging.

@achoum @rstz @thaarres
