### PR TITLE
Autoload shared libraries

### DIFF
--- a/conifer/model.py
+++ b/conifer/model.py
@@ -563,7 +563,7 @@ def load_model(filename, shared_library=None, new_config=None):
     model._metadata = metadata + model._metadata
 
     try:
-        if config["backend"] == "cpp":
+        if config["backend"] in ["cpp","xilinxhls"]:
             import importlib
             last_timestamp=int(model._metadata[-2]._to_dict()["time"])
             #look for the shared library in the same directory as the model json if not specified


### PR DESCRIPTION
When a conifer JSON model is loaded conifer is not able to load also the conifer_bridge.so shared libraries (if they were already produced).

This implies:
1. The user must run .compile() every time
2. Every time that the model is re-compiled a new shared library with a different timestamp is created and a new dict is appended in the metadata list in the model JSON

This PR tries to fix this behavior by looking for the shared library with the last timestamp present in the metadata. It looks for it in the same folder of the JSON if the is not specified by the user.
It works for both the xilinx and cpp backends.