### PR TITLE
Change "which" command to POSIX-required "type"

### DIFF
--- a/conifer/backends/xilinxhls/writer.py
+++ b/conifer/backends/xilinxhls/writer.py
@@ -23,7 +23,7 @@ def get_tool_exe_in_path(tool):
 
     tool_exe = _TOOLS[tool]
 
-    if os.system('which {} > /dev/null 2>/dev/null'.format(tool_exe)) != 0:
+    if os.system('type {} > /dev/null 2>/dev/null'.format(tool_exe)) != 0:
         return None
 
     return tool_exe


### PR DESCRIPTION
While working on containerizing I was trying to run the compilation stage in an AlmaLinux 9 container (`docker pull almalinux:9`) and apparently there is no `which` command there. Investigating further, the `which` command is not required by POSIX (list of commands required by POSIX can be found [here](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/contents.html)). An alternative command is `type` which has similar functionality in this context and is required by POSIX.

After changing `which` to `type` in my local copy compilation worked, so I'm suggesting this MR to improve portability.