### PR TITLE
VHDL normalisation fix

### DIFF
--- a/conifer/backends/vhdl/writer.py
+++ b/conifer/backends/vhdl/writer.py
@@ -195,7 +195,7 @@ class VHDLModel(ModelBase):
         newline += "  constant nClasses : integer := {};\n\n".format(n_classes)
         newline += "  subtype tx is signed({} downto 0);\n".format(self._fp_converter.width - 1)
         newline += "  subtype ty is signed({} downto 0);\n".format(self._fp_converter.width - 1)
-        newline += "  constant norm_slice_h : integer := {};\n".format(self._fp_converter.width * 2 - self._fp_converter.fractional_bits - 1)
+        newline += "  constant norm_slice_h : integer := {};\n".format(self._fp_converter.width * 2 - self._fp_converter.integer_bits - 1)
         newline += "  constant norm_slice_l : integer := {};\n".format(self._fp_converter.fractional_bits)
         fout.write(newline)
       else:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -47,10 +47,13 @@ model0 = f_train_skl()
 # compare pairs of backends with different precision at different rounding modes
 hls_cpp_precisions = ['ap_fixed<16,6>', 'ap_fixed<8,4,AP_TRN,AP_WRAP>', 'ap_fixed<8,4,AP_RND,AP_WRAP>', 'ap_fixed<8,4,AP_RND_ZERO,AP_WRAP>',
                       'ap_fixed<8,4,AP_RND,AP_SAT>', 'ap_fixed<18,8>', 'ap_fixed<18,8,AP_RND_CONV,AP_SAT>']
+hls_hdl_precisions = ['ap_fixed<16,6>', 'ap_fixed<18,8>', 'ap_fixed<12,6>']
 # compare configs with mixed precision
 mixed_precision_cfg = {'InputPrecision' : 'ap_fixed<16,6>', 'ScorePrecision' : 'ap_fixed<12,5>'}
 
 tests = [*[Tester(*model0, 'xilinxhls', 'cpp', {'Precision' : p}, {'Precision' : p}) for p in hls_cpp_precisions],
+         *[Tester(*model0, 'xilinxhls', 'vhdl', {'Precision' : p}, {'Precision' : p}) for p in hls_hdl_precisions],
+         Tester(*model0, 'xilinxhls', 'cpp', mixed_precision_cfg, mixed_precision_cfg),
          Tester(*model0, 'xilinxhls', 'vhdl', mixed_precision_cfg, mixed_precision_cfg),
          Tester(*model0, 'xilinxhls', 'xilinxhls', {'Unroll' : True}, {'Unroll' : False})]
 


### PR DESCRIPTION
#77 introduced the proper application of normalisation to the VHDL backend. However a bug in the logic produced incorrect VHDL code that wouldn't compile with some precision choices. This PR:
- fixes norm slice width in VHDL backend
- adds more VHDL configs to backend tests.

3 of the VHDL backend tests fail with master branch, and all pass on this branch