### PR TITLE
Fix FixedPointConverter on OSX

### DIFF
--- a/conifer/utils/fixed_point.py
+++ b/conifer/utils/fixed_point.py
@@ -1,6 +1,6 @@
 import os
 import numpy as np
-from conifer.utils.misc import _ap_include
+from conifer.utils.misc import _ap_include, _gcc_opts
 import logging
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ class FixedPointConverter:
 
     curr_dir = os.getcwd()
     os.chdir(cpp_filedir)
-    cmd = f"g++ -O3 -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) {_ap_include()} {self.sani_type}.cpp -o {self.sani_type}.so"
+    cmd = f"g++ -O3 -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) {_ap_include()} {_gcc_opts()} {self.sani_type}.cpp -o {self.sani_type}.so"
     logger.debug(f'Compiling with command {cmd}')
     try:
       ret_val = os.system(cmd)


### PR DESCRIPTION
This PR adds gcc options needed to compile the FixedPointConverter on OSX - which in turn can enable use of the VHDL backend with a supported tool like GHDL