### PR TITLE
replaced NotImplementedError with just warnings

### DIFF
--- a/conifer/backends/boards/boards.py
+++ b/conifer/backends/boards/boards.py
@@ -85,10 +85,10 @@ class Builder:
     return BoardConfig.default_config()
   
   def write(self):
-    raise NotImplementedError
+    logger.warn('write() not implemented')
   
   def build(self):
-    raise NotImplementedError
+    logger.warn('build() not implemented')
   
 class ZynqBuilder(Builder):
   

--- a/conifer/backends/cpp/writer.py
+++ b/conifer/backends/cpp/writer.py
@@ -124,9 +124,6 @@ class CPPModel(ModelBase):
     os.chdir(curr_dir)
     return y
 
-  def build(self):
-    raise NotImplementedError
-
 def auto_config():
     config = {'Backend' : 'cpp',
               'ProjectName': 'my_prj',

--- a/conifer/model.py
+++ b/conifer/model.py
@@ -279,7 +279,7 @@ class ModelBase:
         '''
         Write the model files to the output directory specified in configuration
         '''
-        raise NotImplementedError
+        logger.warn('Write not implemented')
 
     def compile(self):
         '''
@@ -287,7 +287,7 @@ class ModelBase:
         Writes the project files first.
         Compilation is carried out by the model backend
         '''
-        raise NotImplementedError
+        logger.warn('Compile not implemented')
     
     def draw(self, filename=None):
         '''
@@ -358,7 +358,7 @@ class ModelBase:
         success: bool
                  True if the build completed successfuly, otherwise False  
         '''
-        raise NotImplementedError
+        logger.warn('Build not implemented')
 
     def profile(self, what : Literal["scores", "thresholds", "both"] = "both" , ax=None):
         """Profile the thresholds or scores of the trees in the ensemble for each feature.


### PR DESCRIPTION
This is a really small PR that replaces NotImplementedError with just warnings.

This allows us to have a fixed piece of code that performs everything from the conversion to the evaluation and is backend independent. Otherwise, it will need to comment/uncomment lines or use multiple ifs every time the backend is changed