### PR TITLE
fixed wrong casting of the thresholds

### DIFF
--- a/conifer/backends/cpp/include/conifer.h
+++ b/conifer/backends/cpp/include/conifer.h
@@ -45,13 +45,13 @@ public:
   T operator()(T a, T b) { return a + b; }
 };
 
-template <typename T, typename U>
-std::function<bool (T, U)> createSplit(const std::string& op) {
-    std::function<bool (T, U)> split;
+template <typename T>
+std::function<bool (T, T)> createSplit(const std::string& op) {
+    std::function<bool (T, T)> split;
     if (op == "<") {
-        split = [](const T& a, const U& b) { return a < b; };
+        split = [](const T& a, const T& b) { return a < b; };
     } else if (op == "<=") {
-        split = [](const T& a, const U& b) { return a <= b; };
+        split = [](const T& a, const T& b) { return a <= b; };
     } else {
         throw std::invalid_argument("Invalid operator string: " + op);
     }
@@ -69,7 +69,7 @@ private:
   std::vector<U> value_;
   std::vector<double> threshold;
   std::vector<double> value;
-  std::function<bool (T, U)> split;
+  std::function<bool (T, T)> split;
 
 public:
 
@@ -84,7 +84,7 @@ public:
     return value_[i];
   }
 
-  void init_(std::function<bool (T, U)> split){
+  void init_(std::function<bool (T, T)> split){
     /* Since T, U types may not be readable from the JSON, read them to double and the cast them here */
     this->split = split;
     std::transform(threshold.begin(), threshold.end(), std::back_inserter(threshold_),
@@ -124,7 +124,7 @@ public:
     nlohmann::json j = nlohmann::json::parse(ifs);
     from_json(j, *this);
     auto splitting_convention = j.value("splitting_convention", "<="); // read the splitting convention with default value of "<=" if it's unspecified
-    auto split = createSplit<T,U>(splitting_convention);
+    auto split = createSplit<T>(splitting_convention);
     /* Do some transformation to initialise things into the proper emulation T, U types */
     if(n_classes == 2) n_classes = 1;
     std::transform(init_predict.begin(), init_predict.end(), std::back_inserter(init_predict_),

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -30,7 +30,8 @@ def backend_predict(model, odir, X, y_shape, backend, backend_config):
   cfg['OutputDir'] = odir
   model = conifer.converters.convert_from_sklearn(model, cfg)
   model.compile()
-  y = model.decision_function(X).reshape(y_shape)   
+  y = model.decision_function(X).reshape(y_shape)
+  return y
 
 class Tester:
    def __init__(self, model, X, y_shape, backend_a, backend_b, config_a={}, config_b={}):
@@ -68,6 +69,7 @@ def test_backend_equality(test):
   y_a = backend_predict(test.model, name_a, test.X, test.y_shape, test.backend_a, test.config_a)
   y_b = backend_predict(test.model, name_b, test.X, test.y_shape, test.backend_b, test.config_b)
   np.testing.assert_array_equal(y_a, y_b)
+  assert((y_a is not None) and (y_b is not None)), "backend_predict returned None for the predictions: inconclusive test"
 
 def test_py_backend():
    clf, X, _ = model0


### PR DESCRIPTION
This PR fixes an issue introduced in the cpp backend by the "splitting convention" PR https://github.com/thesps/conifer/pull/76 .

The template of the splitting function was `std::function<bool (T, U)> split` but in the cpp backend inputs and thresholds are forced to be the same type and U is the score type, so all the thresholds were casted to the same type of the scores.

I quickly checked all the others backends and it seems to me that the cpp is the only one affected