### PR TITLE
Add GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,27 @@
+stages:
+  - generate
+  - trigger
+  - test
+
+generator:
+  stage: generate
+  image: python:3.8-alpine
+  tags:
+    - k8s-default
+  before_script:
+    - pip install pyyaml
+  script:
+    - cd test/pytest
+    - python analyze_tests.py
+  artifacts:
+    paths:
+      - test/pytests.yml
+
+pytests:
+  stage: trigger
+  trigger:
+    include:
+      - local: test/ci.yml
+      - artifact: test/pytests.yml
+        job: generator
+    strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,17 +11,17 @@ generator:
   before_script:
     - pip install pyyaml
   script:
-    - cd test/pytest
+    - cd tests
     - python analyze_tests.py
   artifacts:
     paths:
-      - test/pytests.yml
+      - tests/pytests.yml
 
 pytests:
   stage: trigger
   trigger:
     include:
-      - local: test/ci.yml
-      - artifact: test/pytests.yml
+      - local: tests/ci.yml
+      - artifact: tests/pytests.yml
         job: generator
     strategy: depend

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,6 +3,7 @@ onnxruntime
 scipy
 onnxmltools
 scikit-learn
+skl2onnx
 xgboost<3.0.0
 pybind11<3.0.0
 ydf

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,7 +3,7 @@ onnxruntime
 scipy
 onnxmltools
 scikit-learn
-xgboost<2.0.0
-pybind11
+xgboost<3.0.0
+pybind11<3.0.0
 ydf
 pandas

--- a/tests/analyze_tests.py
+++ b/tests/analyze_tests.py
@@ -6,7 +6,14 @@ pytest.{name}:
   extends: .pytest-{extends}
   variables:
     PYTESTFILE: {test_file}
+  allow_failure: {allow_failure}
 '''
+
+# override the auto detection of which script to extend for the following jobs
+extends_override = {'backends' : 'fpga'}
+
+# allow the following jobs to fail
+allow_failure = ['backends', 'xgb_converter', 'onnx_to_hls']
 
 # check whether "build" method is called in the test -> needs different resources
 def calls_build(test_filename):
@@ -26,9 +33,13 @@ def generate_test_yaml(directory='.'):
         name = file_name.replace('test_', '').replace('.py', '')
         build = calls_build(test_file)
         extends = 'fpga' if build else 'plain'
+        if name in extends_override.keys():
+            extends = extends_override[name]
+        allow_fail = 'True' if name in allow_failure else 'False'
         test_yml = yaml.safe_load(template.format(name=name,
                                                   extends=extends,
-                                                  test_file=test_file))
+                                                  test_file=test_file,
+                                                  allow_failure=allow_fail))
         if yml is None:
             yml = test_yml
         else:

--- a/tests/analyze_tests.py
+++ b/tests/analyze_tests.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import yaml
+
+template = '''
+pytest.{}:
+    extends: .pytest
+    image: {}
+    variables:
+        PYTESTFILE: {}
+'''
+
+images = {'build' : 'registry.cern.ch/ci4fpga/vivado:2024.1',
+          'no build' : 'registry.cern.ch/ci4fpga/ubuntu'}
+
+# check whether "build" method is called in the test -> needs different resources
+def calls_build(test_filename):
+    with open(test_filename) as f:
+        content = f.read()
+        return '.build(' in content
+        
+def generate_test_yaml(directory='.'):
+    # List of test files to scan
+    test_dir = Path(directory)
+    test_files = list(test_dir.glob("test_*.py"))
+
+    yml = None
+
+    for test_file in test_files:
+        file_name = str(test_file)
+        name = file_name.replace('test_', '').replace('.py', '')
+        build = 'build' if calls_build(test_file) else 'no build'
+        test_yml = yaml.safe_load(template.format(name, build, test_file))
+        if yml is None:
+            yml = test_yml
+        else:
+            yml.update(test_yml)
+
+    return yml
+
+if __name__ == '__main__':
+    yml = generate_test_yaml(Path(__file__).parent)
+    with open('pytests.yml', 'w') as yamlfile:
+        yaml.safe_dump(yml, yamlfile)

--- a/tests/analyze_tests.py
+++ b/tests/analyze_tests.py
@@ -2,15 +2,11 @@ from pathlib import Path
 import yaml
 
 template = '''
-pytest.{}:
-    extends: .pytest
-    image: {}
-    variables:
-        PYTESTFILE: {}
+pytest.{name}:
+  extends: .pytest-{extends}
+  variables:
+    PYTESTFILE: {test_file}
 '''
-
-images = {'build' : 'registry.cern.ch/ci4fpga/vivado:2024.1',
-          'no build' : 'registry.cern.ch/ci4fpga/ubuntu'}
 
 # check whether "build" method is called in the test -> needs different resources
 def calls_build(test_filename):
@@ -28,8 +24,11 @@ def generate_test_yaml(directory='.'):
     for test_file in test_files:
         file_name = str(test_file)
         name = file_name.replace('test_', '').replace('.py', '')
-        build = 'build' if calls_build(test_file) else 'no build'
-        test_yml = yaml.safe_load(template.format(name, images[build], test_file))
+        build = calls_build(test_file)
+        extends = 'fpga' if build else 'plain'
+        test_yml = yaml.safe_load(template.format(name=name,
+                                                  extends=extends,
+                                                  test_file=test_file))
         if yml is None:
             yml = test_yml
         else:

--- a/tests/analyze_tests.py
+++ b/tests/analyze_tests.py
@@ -29,7 +29,7 @@ def generate_test_yaml(directory='.'):
         file_name = str(test_file)
         name = file_name.replace('test_', '').replace('.py', '')
         build = 'build' if calls_build(test_file) else 'no build'
-        test_yml = yaml.safe_load(template.format(name, build, test_file))
+        test_yml = yaml.safe_load(template.format(name, images[build], test_file))
         if yml is None:
             yml = test_yml
         else:

--- a/tests/ci.yml
+++ b/tests/ci.yml
@@ -1,7 +1,7 @@
 .snippets:
   mambaforge_setup:
     - apt update
-    - apt install build-essential
+    - apt -y install build-essential
   before_script:
     - git clone --depth 1 --branch v3.12.0 https://github.com/nlohmann/json.git
     - export JSON_ROOT=$(pwd)/json/single_include/

--- a/tests/ci.yml
+++ b/tests/ci.yml
@@ -4,15 +4,10 @@
   tags:
     - fpga-mid
   before_script:
-    - # install g++
-    - # apt update
-    - # apt install -y build-essential
-    - # setup conifer external requirements
     - git clone --depth 1 --branch v3.12.0 https://github.com/nlohmann/json.git
     - export JSON_ROOT=$(pwd)/json/single_include/
     - git clone --depth 1 https://github.com/Xilinx/HLS_arbitrary_Precision_Types.git
     - export XILINX_AP_INCLUDE=$(pwd)/HLS_arbitrary_Precision_Types/include
-    - # setup test python environment
     - pip install -r dev_requirements.txt
     - pip install .
   script:

--- a/tests/ci.yml
+++ b/tests/ci.yml
@@ -1,0 +1,24 @@
+.pytest:
+  stage: test
+  #image: registry.cern.ch/ci4fpga/vivado:2024.1
+  tags:
+    - fpga-mid
+  before_script:
+    - # install g++
+    - # apt update
+    - # apt install -y build-essential
+    - # setup conifer external requirements
+    - git clone --depth 1 --branch v3.12.0 https://github.com/nlohmann/json.git
+    - export JSON_ROOT=$(pwd)/json/single_include/
+    - git clone --depth 1 https://github.com/Xilinx/HLS_arbitrary_Precision_Types.git
+    - export XILINX_AP_INCLUDE=$(pwd)/HLS_arbitrary_Precision_Types/include
+    - # setup test python environment
+    - pip install -r dev_requirements.txt
+    - pip install .
+  script:
+    - cd tests
+    - pytest $PYTESTFILE -rA
+  artifacts:
+    when: always
+    paths:
+      - tests/prj*

--- a/tests/ci.yml
+++ b/tests/ci.yml
@@ -1,8 +1,7 @@
-.pytest:
-  stage: test
-  #image: registry.cern.ch/ci4fpga/vivado:2024.1
-  tags:
-    - fpga-mid
+.snippets:
+  mambaforge_setup:
+    - apt update
+    - apt install build-essential
   before_script:
     - git clone --depth 1 --branch v3.12.0 https://github.com/nlohmann/json.git
     - export JSON_ROOT=$(pwd)/json/single_include/
@@ -10,6 +9,9 @@
     - export XILINX_AP_INCLUDE=$(pwd)/HLS_arbitrary_Precision_Types/include
     - pip install -r dev_requirements.txt
     - pip install .
+
+.pytest:
+  stage: test
   script:
     - cd tests
     - pytest $PYTESTFILE -rA
@@ -17,3 +19,20 @@
     when: always
     paths:
       - tests/prj*
+
+.pytest-plain:
+  extends: .pytest
+  image: condaforge/mambaforge
+  tags:
+    - k8s-default
+  before_script:
+    - !reference [.snippets, mambaforge_setup]
+    - !reference [.snippets, before_script]
+
+.pytest-fpga:
+  extends: .pytest
+  image: registry.cern.ch/ci4fpga/vivado:2024.1
+  tags:
+    - fpga-mid
+  before_script:
+    - !reference [.snippets, before_script]

--- a/tests/ci.yml
+++ b/tests/ci.yml
@@ -1,7 +1,11 @@
 .snippets:
-  mambaforge_setup:
+  ghdl_docker_setup:
     - apt update
-    - apt -y install build-essential
+    - apt install -y build-essential wget git ca-certificates
+    - wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+    - bash Miniforge3.sh -b -p "${HOME}/conda"
+    - source "${HOME}/conda/etc/profile.d/mamba.sh"
+    - mamba activate
   before_script:
     - git clone --depth 1 --branch v3.12.0 https://github.com/nlohmann/json.git
     - export JSON_ROOT=$(pwd)/json/single_include/
@@ -22,11 +26,11 @@
 
 .pytest-plain:
   extends: .pytest
-  image: condaforge/mambaforge
+  image: ghdl/ghdl:6.0.0-dev-gcc-ubuntu-22.04
   tags:
     - k8s-default
   before_script:
-    - !reference [.snippets, mambaforge_setup]
+    - !reference [.snippets, ghdl_docker_setup]
     - !reference [.snippets, before_script]
 
 .pytest-fpga:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,9 @@
 import pytest
+import logging
 from tests.util import train_skl, hls_convert, vhdl_convert, predict
+
+@pytest.fixture(autouse=True)
+def no_logs_gte_error(caplog):
+    yield
+    errors = [record for record in caplog.get_records('call') if record.levelno >= logging.ERROR]
+    assert not errors


### PR DESCRIPTION
This PR adds Continuous Integration via a mirror on CERN GitLab. It includes:
- dynamic pipeline generated by scanning `test_*.py` files in the `test/` directory
- automatic allocation of jobs to generic runners or ci4fpga runners based on use of `build` in the test
- allows overriding of job runner type allocation and allows some tests to fail

Currently the setup runs as expected, generating the dynamic pipeline and allocating to the correct runner types as intended. Three tests currently fail, but they fail outside of the CI too. In order for this to proceed, these are marked as allowed to fail, and issues will be opened to fix those tests:
- `test_backends.py`
- `test_xgb_converter.py`
-  `test_onnx_to_hls.py`