### PR TITLE
fix for pybind11 v3

### DIFF
--- a/conifer/backends/cpp/writer.py
+++ b/conifer/backends/cpp/writer.py
@@ -101,8 +101,9 @@ class CPPModel(ModelBase):
       logger.debug(f'Importing conifer_bridge_{self._stamp} from conifer_bridge_{self._stamp}.so')
       import importlib.util
       spec = importlib.util.spec_from_file_location(f'conifer_bridge_{self._stamp}', f'./conifer_bridge_{self._stamp}.so')
-      self.bridge = importlib.util.module_from_spec(spec).BDT(f"{cfg.project_name}.json")
-      spec.loader.exec_module(self.bridge)
+      module = importlib.util.module_from_spec(spec)
+      spec.loader.exec_module(module)
+      self.bridge = module.BDT(f"{cfg.project_name}.json")
     except ImportError:
       os.chdir(curr_dir)
       raise Exception("Can't import pybind11 bridge, is it compiled?")

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -5,6 +5,6 @@ onnxmltools
 scikit-learn
 skl2onnx
 xgboost<3.0.0
-pybind11<3.0.0
+pybind11
 ydf
 pandas


### PR DESCRIPTION
The issue raised in #91 relates to improperly trying to access the `BDT` class of the C++ bridge module before loading the module. This PR fixes that. The HLS backend does a similar loading, but doesn't have the same issue because the module there isn't using a class.