### PR TITLE
xgboost converter updates

### DIFF
--- a/conifer/converters/xgboost.py
+++ b/conifer/converters/xgboost.py
@@ -1,6 +1,8 @@
 import json
 import xgboost as xgb
 import pandas
+from scipy.special import logit
+import numpy as np
 from packaging import version
 from typing import Union
 import logging
@@ -40,7 +42,7 @@ def convert(bdt : Union[xgb.core.Booster, xgb.XGBClassifier, xgb.XGBRegressor]):
                     'n_classes' : n_classes,
                     'n_features' : n_features,
                     'trees' : [],
-                    'init_predict' : [0] * fn_classes,
+                    'init_predict' : parse_base_score(meta, fn_classes),
                     'norm' : 1,
                     'library':'xgboost',
                     'splitting_convention': splitting_conventions['xgboost'],
@@ -79,3 +81,29 @@ def treeToDict(tree : pandas.DataFrame, feature_names):
               'value'          : values
               }
   return treeDict
+
+def parse_base_score(meta_json, n_classes):
+  '''
+  Extract the base score from the learner
+  '''
+  if __xgb_version >= version.parse('2'):
+
+    objective = meta_json.get('learner').get('objective').get('name')
+    _proba_objectives = ['reg:logistic', 'binary:logistic', 'multi:softmax', 'multi:softprob']
+    base_score_string = meta_json.get('learner').get('learner_model_param').get('base_score')
+    base_score_string_values = base_score_string.strip('[]').split(',')
+    base_score_float = list(map(float, base_score_string_values))
+    all_zeros = not np.any(base_score_float)
+    if not all_zeros:
+      # for objectives predicting probabilities, take the logit to get a raw base score
+      # otherwise the base score is already a raw value (e.g. regression)
+      if objective in _proba_objectives:
+        base_score = logit(base_score_float).tolist()
+      else:
+        base_score = base_score_float
+      assert len(base_score) == n_classes, f'Expected {n_classes} base_scores values, got {len(base_score)}'
+      return base_score
+    else:
+      return [0.] * n_classes
+  else:
+    return [0.] * n_classes

--- a/conifer/converters/xgboost.py
+++ b/conifer/converters/xgboost.py
@@ -18,7 +18,7 @@ def convert(bdt : Union[xgb.core.Booster, xgb.XGBClassifier, xgb.XGBRegressor]):
       bst = bdt.get_booster()
     meta = json.loads(bst.save_config())
     if __xgb_version >= version.parse('2'):
-      logger.warning(f'xgboost versions >= 2.0.0 are not yet fully supported. You have xgboost {__xgb_version}')
+      logger.warning(f'Some prediction disagreements are observed for xgboost versions >= 2.0.0. You have xgboost {__xgb_version}. Extra validation is advised.')
       max_depth = int(meta.get('learner').get('gradient_booster').get('tree_train_param').get('max_depth'))
     else:
       updater = meta.get('learner').get('gradient_booster').get('gbtree_train_param').get('updater').split(',')[0]

--- a/conifer/converters/xgboost.py
+++ b/conifer/converters/xgboost.py
@@ -101,6 +101,8 @@ def parse_base_score(meta_json, n_classes):
         base_score = logit(base_score_float).tolist()
       else:
         base_score = base_score_float
+      if len(base_score) == 1: # expected with xgboost 2 but not xgboost 3
+        base_score = [base_score[0]] * n_classes
       assert len(base_score) == n_classes, f'Expected {n_classes} base_scores values, got {len(base_score)}'
       return base_score
     else:

--- a/conifer/model.py
+++ b/conifer/model.py
@@ -127,9 +127,11 @@ class DecisionTreeBase:
       y[i] = n
     return y
 
-  def decision_function(self, X):
+  def decision_function(self, X, return_leaf=False):
     assert len(X.shape) == 2, 'Expected 2D input'
     yi = self.apply(X)
+    if return_leaf:
+      return yi
     return np.array(self.value)[yi]
 
 class ConfigBase:
@@ -330,7 +332,7 @@ class ModelBase:
             graph.write(filename, format=extension)
         return graph
 
-    def decision_function(self, X, trees=False):
+    def decision_function(self, X, trees=False, return_leaf=False):
         '''
         Compute the decision function of `X`.
         The backend performs the actual computation
@@ -339,7 +341,13 @@ class ModelBase:
         ----------
         X: array-like of shape (n_samples, n_features)
             Input sample
-        
+
+        trees: bool, optional
+            If True, returns the decision function of each tree in the ensemble. Otherwise, returns the sum of the decision function of all trees. Defaults to False.
+
+        return_leaf: bool, optional
+            If True, returns the leaf node indices of each tree in the ensemble. Otherwise, returns the decision function. Defaults to False.
+
         Returns
         ----------    
         score: ndarray of shape (n_samples, n_classes) or (n_samples,)   
@@ -353,7 +361,9 @@ class ModelBase:
         y = np.zeros((self.n_trees, n_classes, n_samples))
         for it, trees in enumerate(self.trees):
             for ic, tree_c in enumerate(trees):
-                y[it, ic] = tree_c.decision_function(X)
+                y[it, ic] = tree_c.decision_function(X, return_leaf=return_leaf)
+        if return_leaf:
+            return np.squeeze(np.transpose(y))
         y = (np.transpose(np.sum(y, axis=0)) + self.init_predict) * self.norm
         return np.squeeze(y)
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,7 +4,7 @@ scipy
 onnxmltools
 scikit-learn
 skl2onnx
-xgboost<3.0.0
+xgboost
 pybind11
 ydf
 pandas

--- a/tests/test_xgb_converter.py
+++ b/tests/test_xgb_converter.py
@@ -76,9 +76,42 @@ def test_xgb(params):
   else:
     model = get_model_function(X, y, get_model_kwargs)
   cnf_model = conifer.converters.convert_from_xgboost(model)
-  y_cnf = np.squeeze(transform(cnf_model.decision_function(X), **transform_kwargs))
+
+  # get the inference data in the correct format
   X_xgb = X if data_fmt == 'np' else d
+
+  # get leaf index predictions
+  y_cnf_leaf = cnf_model.decision_function(X, return_leaf=True)
+  # conifer y_cnf_leaf shape is (batch, class, tree) but xgboost is (batch, tree, class) with the (tree and class) squashed, reshape:
+  if len(y_cnf_leaf.shape) == 3:
+    y_cnf_leaf = np.transpose(y_cnf_leaf, (0, 2, 1)).reshape(y_cnf_leaf.shape[0], -1)
+
+  if isinstance(model, xgb.core.Booster): # only Booster has pred_leaf option
+    y_xgb_leaf = model.predict(X_xgb, pred_leaf=True)
+  else:
+    y_xgb_leaf = model.get_booster().predict(d, pred_leaf=True)
+
+  # get numerical predictions
+  y_cnf = np.squeeze(transform(cnf_model.decision_function(X), **transform_kwargs))
   y_xgb = getattr(model, predictor)(X_xgb)
   if len(y_xgb.shape) == 2 and y_xgb.shape[1] == 2:
     y_xgb = y_xgb[:,-1]
-  np.testing.assert_array_almost_equal(y_cnf, y_xgb)
+
+  # test only the examples where the same leaf was reached for the numerical test
+  if len(y_xgb_leaf.shape) == 1: # single tree, single class special case
+    same_leaf_sel = y_cnf_leaf == y_xgb_leaf
+  else:
+    same_leaf_sel = np.all(y_cnf_leaf == y_xgb_leaf, axis=1)
+  y_cnf_test = y_cnf[same_leaf_sel]
+  y_xgb_test = y_xgb[same_leaf_sel]
+
+  # first do a test based on the fraction of correct leaves reached
+  leaf_denominator = np.prod(y_xgb_leaf.shape)
+  leaf_numerator = leaf_denominator - np.sum(y_cnf_leaf == y_xgb_leaf)
+  same_leaf_fraction = leaf_numerator / leaf_denominator
+  assert same_leaf_fraction < 1e-3, f"Mismatched leaf reached in {leaf_numerator} of {leaf_denominator} cases ({100*leaf_numerator/leaf_denominator:.4f}%)"
+  print(f"PASS: Mismatched leaf reached in {leaf_numerator} of {leaf_denominator} cases ({100*leaf_numerator/leaf_denominator:.4f}%)")
+
+  # second do a test based on the numerical predictions for the examples where the same leaf was reached
+  np.testing.assert_array_almost_equal(y_cnf_test, y_xgb_test)
+  print("PASS: numerical predictions agree well for examples where the same leaf was reached")


### PR DESCRIPTION
The XGBoost converter hasn't worked that well since XGBoost version 2 (now at 3.3.0). This PR implements some missed feature - the model initial prediction / base score, and updates the tests. 

Before this update, using the new test script, all of the tests failed based on numerical mismatches. Now, 3 of the tests pass and 3 of the tests fail due to _leaf_ mismatches. I observed that even a single tree model would show numerical mismatches - hinting that reaching a different leaf was an issue as well as the different numerical values from the missing base score. The issue of reaching a wrong leaf is not fixed by this PR, but the testing is now able to help isolate the two types of issues.

Reaching a wrong leaf will be addressed in a future update, and seems to occur specifically for values which are very close to a decision threshold.