### PR TITLE
Support Vitis >= 2025.1 by updating tool discovery

### DIFF
--- a/conifer/backends/common.py
+++ b/conifer/backends/common.py
@@ -4,6 +4,55 @@ import xml.etree.ElementTree as ET
 import re
 import os
 
+# HLS tools that can run the build Tcl scripts, in order of preference.
+# vitis_hls was removed in Vitis 2025.1.
+_TOOLS = {
+    'vivadohls': 'vivado_hls',
+    'vitishls': 'vitis_hls',
+    'vitis_unified': 'vitis-run'
+}
+
+
+def get_tool_exe_in_path(tool):
+    if tool not in _TOOLS.keys():
+        return None
+
+    tool_exe = _TOOLS[tool]
+
+    if os.system('type {} > /dev/null 2>/dev/null'.format(tool_exe)) != 0:
+        return None
+
+    return tool_exe
+
+
+def get_hls():
+
+    tool_exe = None
+
+    for tool in _TOOLS.keys():
+        tool_exe = get_tool_exe_in_path(tool)
+        if tool_exe != None:
+            break
+
+    return tool_exe
+
+
+def get_hls_build_command(tool_exe, tcl_script):
+    '''
+    Get the shell command running a build Tcl script with the discovered HLS tool
+    Parameters
+    ----------
+    tool_exe : string
+        name of the HLS tool executable, one of the values of _TOOLS
+    tcl_script : string
+        name of the Tcl script to run
+    '''
+    if tool_exe == 'vitis-run':
+        return f'vitis-run --mode hls --tcl {tcl_script}'
+    else:
+        return f'{tool_exe} -f {tcl_script}'
+
+
 class BottomUpDecisionTree(DecisionTreeBase):
   _tree_fields = DecisionTreeBase._tree_fields + ['parent', 'depth', 'iLeaf']
   def __init__(self, treeDict, splitting_convention):

--- a/conifer/backends/fpu/writer.py
+++ b/conifer/backends/fpu/writer.py
@@ -9,6 +9,7 @@ import logging
 logger = logging.getLogger(__name__)
 from conifer.model import ModelBase, ConfigBase, ModelMetaData
 from conifer.utils import copydocstring
+from conifer.backends.common import _TOOLS, get_hls, get_hls_build_command
 from conifer.backends.boards import get_board_config, get_builder, BoardConfig, ZynqConfig, AlveoConfig
 
 class FPUInterfaceNode:
@@ -418,9 +419,14 @@ class FPUBuilder:
     os.chdir(self.output_dir)
     success = True
     if csynth:
-      cmd = 'vitis_hls -f build_hls.tcl > hls_build.log'
-      logger.info(f'Building FPU HLS with command "{cmd}"')
-      success = success and os.system(cmd)==0
+      hls_tool = get_hls()
+      if hls_tool is None:
+        logger.error("No HLS in PATH (looked for {}). Did you source the appropriate Xilinx Toolchain?".format(', '.join(_TOOLS.values())))
+        success = False
+      else:
+        cmd = f'{get_hls_build_command(hls_tool, "build_hls.tcl")} > hls_build.log'
+        logger.info(f'Building FPU HLS with command "{cmd}"')
+        success = success and os.system(cmd)==0
     if success and bitfile:
       success = success and self.board_builder.build(**build_kwargs)
     os.chdir(cwd)

--- a/conifer/backends/xilinxhls/hls-template/build_hls.tcl
+++ b/conifer/backends/xilinxhls/hls-template/build_hls.tcl
@@ -13,10 +13,21 @@ array set opt {
     vsynth     0
 }
 
-foreach arg $::argv {
-  foreach o [lsort [array names opt]] {
-    regexp "$o=+(\\w+)" $arg unused opt($o)
-  }
+# conifer writes the build options to build_opt.tcl, since the unified
+# vitis-run CLI (Vitis >=2025.1) cannot forward cli args to the script
+# (no tclargs in https://docs.amd.com/r/en-US/ug1702-vitis-accelerated-reference/vitis-run-Command)
+if {[file exists [file join $tcldir build_opt.tcl]]} {
+    source [file join $tcldir build_opt.tcl]
+}
+
+# CLI args override the file options when running the script directly
+# with the classic tools, e.g. vitis_hls -f build_hls.tcl "csim=1"
+if {[info exists ::argv]} {
+    foreach arg $::argv {
+        foreach o [lsort [array names opt]] {
+            regexp "$o=+(\\w+)" $arg unused opt($o)
+        }
+    }
 }
 
 file mkdir tb_data

--- a/conifer/backends/xilinxhls/writer.py
+++ b/conifer/backends/xilinxhls/writer.py
@@ -5,40 +5,12 @@ import numpy as np
 import copy
 from conifer.utils import _ap_include, _gcc_opts, _py_executable, copydocstring
 from conifer.backends.common import BottomUpDecisionTree, MultiPrecisionConfig, read_hls_report, read_vsynth_report
+from conifer.backends.common import _TOOLS, get_tool_exe_in_path, get_hls, get_hls_build_command
 from conifer.backends.boards import get_board_config, get_builder, BoardConfig, AlveoConfig, ZynqConfig
 from conifer.model import ModelBase, ConfigBase
 import datetime
 import logging
 logger = logging.getLogger(__name__)
-
-_TOOLS = {
-    'vivadohls': 'vivado_hls',
-    'vitishls': 'vitis_hls'
-}
-
-
-def get_tool_exe_in_path(tool):
-    if tool not in _TOOLS.keys():
-        return None
-
-    tool_exe = _TOOLS[tool]
-
-    if os.system('type {} > /dev/null 2>/dev/null'.format(tool_exe)) != 0:
-        return None
-
-    return tool_exe
-
-
-def get_hls():
-
-    tool_exe = None
-
-    for tool in _TOOLS.keys():
-        tool_exe = get_tool_exe_in_path(tool)
-        if tool_exe != None:
-            break
-
-    return tool_exe
 
 class XilinxHLSAcceleratorConfig(ConfigBase):
     _config_fields = ['interface_type', 'board']
@@ -574,11 +546,18 @@ class XilinxHLSModel(ModelBase):
         rval = True
         hls_tool = get_hls()
         if hls_tool is None:
-            logger.error("No HLS in PATH. Did you source the appropriate Xilinx Toolchain?")
+            logger.error("No HLS in PATH (looked for {}). Did you source the appropriate Xilinx Toolchain?".format(', '.join(_TOOLS.values())))
             rval = False
         else:
-            cmd = '{hls_tool} -f build_hls.tcl "reset={reset} csim={csim} synth={synth} cosim={cosim} export={export}" > build.log'\
-                .format(hls_tool=hls_tool, reset=reset, csim=csim, synth=synth, cosim=cosim, export=export)
+            # write the build options to a file sourced by build_hls.tcl, since the
+            # unified vitis-run CLI cannot forward command line arguments to the script
+            opts = {'reset': reset, 'csim': csim, 'synth': synth, 'cosim': cosim, 'export': export}
+            with open('build_opt.tcl', 'w') as f:
+                f.write('array set opt {\n')
+                for opt, val in opts.items():
+                    f.write(f'    {opt} {int(val)}\n')
+                f.write('}\n')
+            cmd = f'{get_hls_build_command(hls_tool, "build_hls.tcl")} > build.log'
             start = datetime.datetime.now()
             logger.info(f'build starting {start:%H:%M:%S}')
             logger.debug(f'build invoking {hls_tool} with command "{cmd}"')

--- a/tests/test_hls_tools.py
+++ b/tests/test_hls_tools.py
@@ -1,0 +1,46 @@
+'''
+Test HLS tool discovery and build command construction
+'''
+
+import stat
+import pytest
+from conifer.backends.common import get_hls, get_hls_build_command
+
+
+def make_stub(bindir, name):
+    '''Create a fake tool executable to be discovered on PATH'''
+    path = bindir / name
+    path.write_text('#!/bin/sh\nexit 0\n')
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+# https://docs.pytest.org/en/stable/reference/reference.html#pytest.MonkeyPatch.setenv
+@pytest.fixture
+def bindir(tmp_path, monkeypatch):
+    d = tmp_path / 'bin'
+    d.mkdir()
+    monkeypatch.setenv('PATH', str(d))
+    return d
+
+
+def test_no_tool_in_path(bindir):
+    assert get_hls() is None
+
+
+def test_discover_vitis_unified(bindir):
+    # Vitis 2025.1 and later ship only the unified CLI
+    make_stub(bindir, 'vitis-run')
+    assert get_hls() == 'vitis-run'
+
+
+def test_prefer_classic_vitis_hls(bindir):
+    # both tools are available from Vitis 2023.2 to 2024.2, prefer the classic one
+    make_stub(bindir, 'vitis-run')
+    make_stub(bindir, 'vitis_hls')
+    assert get_hls() == 'vitis_hls'
+
+
+def test_build_commands():
+    assert get_hls_build_command('vivado_hls', 'build_hls.tcl') == 'vivado_hls -f build_hls.tcl'
+    assert get_hls_build_command('vitis_hls', 'build_hls.tcl') == 'vitis_hls -f build_hls.tcl'
+    assert get_hls_build_command('vitis-run', 'build_hls.tcl') == 'vitis-run --mode hls --tcl build_hls.tcl'


### PR DESCRIPTION
Solves #108 

The `vitis_hls` executable was deprecated in Vitis 2024.1 and removed in Vitis 2025.1, so `model.build()` on the `xilinxhls` backend fails with recent Vitis installations. In the unified CLI, existing HLS Tcl scripts run through `vitis-run --mode hls --tcl <script>` (cf. [source](https://docs.amd.com/r/en-US/ug1702-vitis-accelerated-reference/vitis-run-Command)).

### Changes

- **Tool discovery**: `vitis-run` is added to `_TOOLS` after `vivado_hls` and `vitis_hls`, so behaviour is unchanged wherever the classic tools exist (up to 2024.2). The unified CLI is used from 2025.1 where it is the only option. Discovery moved from the `xilinxhls` writer to `backends/common.py` so the FPU backend can share it instead of hardcoding `vitis_hls`.
- **Tool invocation**: `vitis-run` cannot forward command line arguments to the Tcl script, so `build()` now writes the options (`reset`/`csim`/`synth`/`cosim`/`export`) to a `build_opt.tcl` file which `build_hls.tcl` sources. CLI args still override the file options when running the script directly with the classic tools.
- **Tests**: `tests/test_hls_tools.py` covers the discovery order and build command construction using stub executables, no Xilinx install needed.

### Validation

- Tested the updated tool discover on Vitis 2024.1, 2025.2 and 2026.1 by running:
    - `pytest tests/test_hls_tools.py`
    - `pytest tests/test_skl_to_hls.py`
    - `pytest tests/test_backends.py`. Only tests 4,9 and 11 fail, which was the case before this commit (related to #98 ).

<details><summary>Example before/after test output</summary>
<p>

```shell
~/code/OPL/bdt-aie-openlab/conifer master ≡
opl-conifer-tutorial ❯ pytest tests/test_skl_to_hls.py                                                                                                      (opl-conifer-tutorial) 
=============================================================================== test session starts ===============================================================================
platform linux -- Python 3.13.14, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/theayos/code/OPL/bdt-aie-openlab/conifer
configfile: pytest.ini
collected 4 items                                                                                                                                                                 

tests/test_skl_to_hls.py ..E..                                                                                                                                              [100%]

===================================================================================== ERRORS ======================================================================================
_______________________________________________________________________ ERROR at teardown of test_skl_build _______________________________________________________________________

caplog = <_pytest.logging.LogCaptureFixture object at 0x7f2e63cf5090>

>   ???
E   assert not [<LogRecord: conifer.backends.xilinxhls.writer, 40, /home/theayos/code/OPL/bdt-aie-openlab/conifer/conifer/backends/xilinxhls/writer.py, 577, "No HLS in PATH. Did you source the appropriate Xilinx Toolchain?">]

/home/theayos/code/OPL/bdt-aie-openlab/devconifer/tests/conftest.py:9: AssertionError
------------------------------------------------------------------------------ Captured stderr setup ------------------------------------------------------------------------------
In file included from /home/theayos/miniconda3/envs/opl-conifer-tutorial/include/python3.13/Python.h:14,
                 from /home/theayos/miniconda3/envs/opl-conifer-tutorial/lib/python3.13/site-packages/pybind11/include/pybind11/conduit/wrap_include_python_h.h:44,
                 from /home/theayos/miniconda3/envs/opl-conifer-tutorial/lib/python3.13/site-packages/pybind11/include/pybind11/detail/common.h:12,
                 from /home/theayos/miniconda3/envs/opl-conifer-tutorial/lib/python3.13/site-packages/pybind11/include/pybind11/attr.h:13,
                 from /home/theayos/miniconda3/envs/opl-conifer-tutorial/lib/python3.13/site-packages/pybind11/include/pybind11/detail/class.h:12,
                 from /home/theayos/miniconda3/envs/opl-conifer-tutorial/lib/python3.13/site-packages/pybind11/include/pybind11/pybind11.h:12,
                 from bridge.cpp:25:
/home/theayos/miniconda3/envs/opl-conifer-tutorial/include/python3.13/pyconfig.h:1964:9: warning: ‘_POSIX_C_SOURCE’ redefined
 1964 | #define _POSIX_C_SOURCE 200809L
      |         ^~~~~~~~~~~~~~~
In file included from /usr/include/c++/16/x86_64-pc-linux-gnu/bits/os_defines.h:39,
                 from /usr/include/c++/16/x86_64-pc-linux-gnu/bits/c++config.h:733,
                 from /usr/include/c++/16/bits/requires_hosted.h:31,
                 from /usr/include/c++/16/vector:62,
                 from bridge.cpp:1:
/usr/include/features.h:319:10: note: this is the location of the previous definition
  319 | # define _POSIX_C_SOURCE        202405L
      |          ^~~~~~~~~~~~~~~
/home/theayos/miniconda3/envs/opl-conifer-tutorial/include/python3.13/pyconfig.h:1985:9: warning: ‘_XOPEN_SOURCE’ redefined
 1985 | #define _XOPEN_SOURCE 700
      |         ^~~~~~~~~~~~~
/usr/include/features.h:234:10: note: this is the location of the previous definition
  234 | # define _XOPEN_SOURCE  800
      |          ^~~~~~~~~~~~~
------------------------------------------------------------------------------- Captured log setup --------------------------------------------------------------------------------
2026-08-05 14:48:35 WARNING Could not find hls_stream headers at /home/theayos/code/OPL/bdt-aie-openlab/conifer/conifer/external/hls/ or /home/theayos/code/OPL/HLS_arbitrary_Precision_Types/include//hls_stream.h
-------------------------------------------------------------------------------- Captured log call --------------------------------------------------------------------------------
2026-08-05 14:48:58 ERROR No HLS in PATH. Did you source the appropriate Xilinx Toolchain?
================================================================================ warnings summary =================================================================================
tests/test_skl_to_hls.py::test_skl_hls_predict
  /home/theayos/code/OPL/bdt-aie-openlab/conifer/conifer/backends/common.py:162: SyntaxWarning: invalid escape sequence '\.'
    search = 'Total elapsed time: ([0-9]+)\.*([0-9]*) seconds'

tests/test_skl_to_hls.py::test_skl_hls_predict
  /home/theayos/code/OPL/bdt-aie-openlab/conifer/conifer/backends/common.py:170: SyntaxWarning: invalid escape sequence '\.'
    search = 'peak allocated memory: ([0-9]+)\.*([0-9]*) ([k,M,G])B'

tests/test_skl_to_hls.py::test_hdl_predict
  /home/theayos/miniconda3/envs/opl-conifer-tutorial/lib/python3.13/site-packages/_pytest/python.py:171: PytestReturnNotNoneWarning: Test functions should return None, but tests/test_skl_to_hls.py::test_hdl_predict returned <class 'tuple'>.
  Did you mean to use `assert` instead of `return`?
  See https://docs.pytest.org/en/stable/how-to/assert.html#return-not-none for more information.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= short test summary info =============================================================================
ERROR tests/test_skl_to_hls.py::test_skl_build - assert not [<LogRecord: conifer.backends.xilinxhls.writer, 40, /home/theayos/code/OPL/bdt-aie-openlab/conifer/conifer/backends/xilinxhls/writer.py, 577, "No HLS in PATH. Did ...
=============================================================== 4 passed, 3 warnings, 1 error in 165.89s (0:02:45) ================================================================

~/code/OPL/bdt-aie-openlab/conifer master ≡ 2m 46s
opl-conifer-tutorial ❯ git checkout vitis-unified-cli                                                                                                       (opl-conifer-tutorial) 
Switched to branch 'vitis-unified-cli'
Your branch is up to date with 'origin/vitis-unified-cli'.

~/code/OPL/bdt-aie-openlab/conifer vitis-unified-cli* ≡
opl-conifer-tutorial ❯ pytest tests/test_skl_to_hls.py                                                                                                      (opl-conifer-tutorial) 
=============================================================================== test session starts ===============================================================================
platform linux -- Python 3.13.14, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/theayos/code/OPL/bdt-aie-openlab/conifer
configfile: pytest.ini
collected 4 items                                                                                                                                                                 

tests/test_skl_to_hls.py ....                                                                                                                                               [100%]

================================================================================ warnings summary =================================================================================
tests/test_skl_to_hls.py::test_skl_hls_predict
  /home/theayos/code/OPL/bdt-aie-openlab/conifer/conifer/backends/common.py:211: SyntaxWarning: invalid escape sequence '\.'
    search = 'Total elapsed time: ([0-9]+)\.*([0-9]*) seconds'

tests/test_skl_to_hls.py::test_skl_hls_predict
  /home/theayos/code/OPL/bdt-aie-openlab/conifer/conifer/backends/common.py:219: SyntaxWarning: invalid escape sequence '\.'
    search = 'peak allocated memory: ([0-9]+)\.*([0-9]*) ([k,M,G])B'

tests/test_skl_to_hls.py::test_hdl_predict
  /home/theayos/miniconda3/envs/opl-conifer-tutorial/lib/python3.13/site-packages/_pytest/python.py:171: PytestReturnNotNoneWarning: Test functions should return None, but tests/test_skl_to_hls.py::test_hdl_predict returned <class 'tuple'>.
  Did you mean to use `assert` instead of `return`?
  See https://docs.pytest.org/en/stable/how-to/assert.html#return-not-none for more information.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================== 4 passed, 3 warnings in 224.94s (0:03:44) ====================================================================


``` 

</p>
</details> 